### PR TITLE
Issue 53 - Implemented the assertion for Personal access token information after

### DIFF
--- a/src/main/java/aicore/pages/SettingsMyProfile.java
+++ b/src/main/java/aicore/pages/SettingsMyProfile.java
@@ -1,15 +1,22 @@
 package aicore.pages;
 
 import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
 
 public class SettingsMyProfile {
 	private Page page;
+	private String timestamp;
 	private static final String OPEN_SETTINGS_ICON_XPATH = "//a[@aria-label='Navigate to settings']";
 	private static final String MY_PROFILE_SECTION_TITLE_XPATH = "//h6[text()='{sectionText}']";
 	private static final String PRIVACY_CENTER_XPATH = "//span[text()='Privacy Center']";
+	private static final String DESCRIPTION_FIELD_BUTTON_XPATH = "//label[text()='Description']/following-sibling::div//input";
+	private static final String CANCEL_BUTTON_XPATH = "//button[contains(@class, 'MuiButtonBase-root') and .//span[normalize-space()='Close']]";
+	private static final String GENERATED_KEY_XPATH = "//td[contains(text(),'{keyName}')]";
+	private static final String GENERATED_DESCRIPTION_XPATH = "//td[text()='{description}']";
 
-	public SettingsMyProfile(Page page) {
+	public SettingsMyProfile(Page page, String timestamp) {
 		this.page = page;
+		this.timestamp = timestamp;
 	}
 
 	public void openSettingsIcon() {
@@ -29,6 +36,53 @@ public class SettingsMyProfile {
 	public String verifyPrivacyCenter() {
 		String actualTextMessage = page.textContent(PRIVACY_CENTER_XPATH);
 		return actualTextMessage;
+	}
+
+	public void clickNewKeyButton() {
+		page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("New Key")).click();
+
+	}
+
+	public void enterKeyName(String keyName) {
+		String uniqueKeyName = keyName + timestamp;
+		page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Name")).click();
+		page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Name")).fill(uniqueKeyName);
+	}
+
+	public void enterDescription(String description) {
+		String uniqueDescription = description + timestamp;
+		page.click(DESCRIPTION_FIELD_BUTTON_XPATH);
+		page.fill(DESCRIPTION_FIELD_BUTTON_XPATH, uniqueDescription);
+	}
+
+	public void clickGenerateButton() {
+		page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Generate")).click();
+	}
+
+	public void clickOnCancelButton() {
+		page.click(CANCEL_BUTTON_XPATH);
+	}
+
+	public String getExpectedAccessKeyTitle(String keyName) {
+		String expTitle = keyName + timestamp;
+		return expTitle;
+	}
+
+	public String validateGeneratedKey(String keyName) {
+		String generatedKeyName = page.textContent(GENERATED_KEY_XPATH.replace("{keyName}", keyName + timestamp))
+				.trim();
+		return generatedKeyName;
+	}
+
+	public String validateDescriptionName(String description) {
+		String generatedDescription = page
+				.textContent(GENERATED_DESCRIPTION_XPATH.replace("{description}", description + timestamp)).trim();
+		return generatedDescription;
+	}
+
+	public String getExpectedDescriptionName(String description) {
+		String expDescription = description + timestamp;
+		return expDescription;
 	}
 
 }

--- a/src/test/java/aicore/steps/SettingsMyProfileSteps.java
+++ b/src/test/java/aicore/steps/SettingsMyProfileSteps.java
@@ -6,15 +6,18 @@ import org.junit.jupiter.api.Assertions;
 
 import aicore.hooks.SetupHooks;
 import aicore.pages.SettingsMyProfile;
+import aicore.utils.CommonUtils;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
 public class SettingsMyProfileSteps {
 	private SettingsMyProfile settings;
+	private String timestamp;
 
 	public SettingsMyProfileSteps() {
-		this.settings = new SettingsMyProfile(SetupHooks.getPage());
+		timestamp = CommonUtils.getTimeStampName();
+		this.settings = new SettingsMyProfile(SetupHooks.getPage(), timestamp);
 	}
 
 	@Given("User clicks on Open Settings icon")
@@ -40,4 +43,42 @@ public class SettingsMyProfileSteps {
 		assertTrue("Expected section not found: " + sectionName, isVisible);
 	}
 
+	@When("User clicks on New Key button")
+	public void user_clicks_on_new_key_button() {
+		settings.clickNewKeyButton();
+	}
+
+	@Then("User fills Name as {string} in Name field")
+	public void user_fills_name_as_in_name_field(String newKey) {
+		settings.enterKeyName(newKey);
+	}
+
+	@Then("User fills Description as {string} in Description field")
+	public void user_fills_description_as_in_description_field(String description) {
+		settings.enterDescription(description);
+	}
+
+	@Then("User clicks on Generate button")
+	public void user_clicks_on_generate_button() {
+		settings.clickGenerateButton();
+	}
+
+	@Then("User clicks on Close button")
+	public void user_clicks_on_close_button() {
+		settings.clickOnCancelButton();
+	}
+
+	@Then("User can see generated key name as {string}")
+	public void user_can_see_generated_key_name_as(String keyName) {
+		String actualKeyName = settings.validateGeneratedKey(keyName);
+		String expKeyTitle = settings.getExpectedAccessKeyTitle(keyName);
+		Assertions.assertEquals(actualKeyName, expKeyTitle);
+	}
+
+	@Then("User can see generated key description as {string}")
+	public void user_can_see_generated_key_description_as(String description) {
+		String actualDescription = settings.validateDescriptionName(description);
+		String expDescription = settings.getExpectedDescriptionName(description);
+		Assertions.assertEquals(actualDescription, expDescription);
+	}
 }

--- a/src/test/resources/Features/SettingsMyProfile.feature
+++ b/src/test/resources/Features/SettingsMyProfile.feature
@@ -8,3 +8,15 @@ Scenario: Settings - My Profile Page
   And User can see 'Javascript SDK' section on profile page
   And User can see 'Python SDK' section on profile page
   And User can see 'Personal Access Tokens' section on profile page
+  
+Scenario: Settings - Personal Access Token
+  Given User clicks on Open Settings icon 
+  When User clicks on My Profile
+  And User clicks on New Key button
+  Then User fills Name as 'New Key' in Name field
+  And User fills Description as 'New Description' in Description field
+  And User clicks on Generate button
+  Then User clicks on Close button
+  Then User can see 'Personal Access Tokens' section on profile page
+  And User can see generated key name as 'New Key'
+  And User can see generated key description as 'New Description'


### PR DESCRIPTION
creating key

## Description
- Ensured user is logged in to AI Core.
- Navigated to the My Profile section under Settings.
- Verified the presence of an existing Personal Access Token.
- Validated that the Personal Access Tokens section is visible.
- Asserted that the Access Token information (name, description, etc.) is accurately displayed on the page.

## Changes Made
📂 Files Added/Modified:
Step Definitions (SettingsMyProfileSteps.java)
Page Object Methods (SettingsMyProfile.java)
Feature File (MyAccessTokens.feature)


##  Test Coverage:
Functional UI validation using Playwright and Cucumber
Dynamic timestamp handling to validate token identity
Assertions to match expected vs actual token data