### PR TITLE
Feature/AT-110 Pause and Resume job

### DIFF
--- a/src/main/java/aicore/pages/SettingsMyProfile.java
+++ b/src/main/java/aicore/pages/SettingsMyProfile.java
@@ -26,7 +26,7 @@ public class SettingsMyProfile {
 	}
 
 	public void openSettingsIcon() {
-		page.getByTestId(OPEN_SETTINGS_ICON_XPATH).click();
+		page.getByTestId(OPEN_SETTINGS_ICON_XPATH).click();;
 	}
 
 	public void clickOnMyProfileCard() {

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -55,7 +55,7 @@ BIDataImportExcelFile=./src/test/resources/data/BIDataImportsTestData.xlsx
 use_video=false
 
 ## Use Traces
-use_trace=true
+use_trace=false
 
 ## Use state
 use_state=false

--- a/src/test/java/aicore/runners/AICoreTestRunner.java
+++ b/src/test/java/aicore/runners/AICoreTestRunner.java
@@ -6,7 +6,7 @@ import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = "src/test/resources/Features/jobs/Jobs.feature", glue = { "aicore.steps", "aicore.hooks" }, plugin = {
+@CucumberOptions(features = "src/test/resources/Features", glue = { "aicore.steps", "aicore.hooks" }, plugin = {
 		"pretty", "html:target/cucumber-report.html" }, monochrome = true, dryRun = false)
 
 public class AICoreTestRunner {

--- a/src/test/resources/Features/jobs/Jobs.feature
+++ b/src/test/resources/Features/jobs/Jobs.feature
@@ -4,7 +4,6 @@ Feature: Job Management
     Given User clicks on Open Settings Engine
     And User clicks on Jobs Icon
 
-  @tag1
   Scenario: Pause a Running Job
     When User clicks the checkbox of "Test Job"
     And User clicks the green Pause button
@@ -12,7 +11,6 @@ Feature: Job Management
     And the checkbox of "Test Job" should become unselected
     And the green Pause button should revert to its default state
 
-  @tag2
   Scenario: Resume a Paused Job
     When User clicks the checkbox of Paused "New Job"
     And User clicks the Resume button


### PR DESCRIPTION
Description
Update Jobs Settings

Changes Made
Jobs.feature
JobsSteps.java
JobsPage.java

How to Test
Scenario 1:
User login as an admin/Native
User go to the settings page
User go to the Jobs page 
User is on the Jobs page
User click on the checkbox of Active job
User clicks the Pause button 

Scenario 2:
User login as an admin/Native
User go to the settings page
User go to the Jobs page 
User is on the Jobs page
User click on the checkbox of Paused job
User clicks the Resume button

Notes
Please find the attached video for local testing for both Scenarios
[Jobs.webm](https://github.com/user-attachments/assets/de7cfb97-fa06-43b6-8af7-f171e77f0151)