### PR TITLE
feat(issue-375): verify the Title and Buttons on Build page

### DIFF
--- a/src/main/java/aicore/pages/HomePage.java
+++ b/src/main/java/aicore/pages/HomePage.java
@@ -52,6 +52,22 @@ public class HomePage {
 		HomePageUtils.clickOnOpenAppLibrary(page);
 	}
 
+	public void clickOnBuildButton() {
+		HomePageUtils.clickOnBuildButton(page);
+	}
+
+	public void verifyBuildPageButton(String buttonName) {
+		HomePageUtils.verifyBuildPageButton(page, buttonName);
+	}
+
+	public void verifyBuildPageButtons(String buttonName) {
+		HomePageUtils.verifyBuildPageButtons(page, buttonName);
+	}
+
+	public void verifyTitleIsVisible(String titleName) {
+		HomePageUtils.verifyTitleIsVisible(page, titleName);
+	}
+
 	public void logout() {
 		HomePageUtils.logout(page);
 	}

--- a/src/main/java/aicore/utils/HomePageUtils.java
+++ b/src/main/java/aicore/utils/HomePageUtils.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.Logger;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
+import com.microsoft.playwright.options.LoadState;
 
 public class HomePageUtils {
 
@@ -14,6 +15,12 @@ public class HomePageUtils {
 	private static final String PAGE_TITLE_XPATH = "//h6[text()='" + ConfigUtils.getValue("applicationName") + "']";
 	public static final String APP_SEARCH_TEXTBOX_XPATH = "//input[contains(@class,'MuiInputBase-input MuiOutlinedInput-input ') and @placeholder='Search']";
 	// menu options
+	private static final String BUILD_BUTTON_XPATH = "//button[@value='build']";
+	private static final String BUILD_PAGE_TITLE_XPATH = "//*[text()='{title}']";
+	private static final String BUILD_PAGE_BUTTON = "new-app-{Button}-btn";
+	private static final String BUILD_PAGE_BROWSER_TEMPLATE_BUTTON_XPATH = "//button//span[text()='Browse Templates']";
+	private static final String BUILD_PAGE_POPUP_XPATH = "//div[@role='presentation']//div[@role='presentation']";
+	private static final String BUILD_PAGE_POPUP_CLOSE_XPATH = "//button//span[text()='Cancel']";
 	private static final String SEMOSS_MENU_DATA_TESID = "MenuRoundedIcon";
 //	private static final String SEMOSS_OPEN_MEN_DATA_XPATH = "//a[@aria-label='Go Home']/parent::div//*[@data-testid='CloseIcon']";
 	private static final String SEMOSS_OPEN_MEN_DATA_TESTID = "MenuOpenRoundedIcon";
@@ -119,6 +126,62 @@ public class HomePageUtils {
 		Locator locator = page.locator(APP_MENU_BUTTON_XPATH);
 		locator.click();
 		HomePageUtils.closeMainMenu(page);
+	}
+	
+	public static void clickOnBuildButton(Page page) {
+		Locator BuildButton = page.locator(BUILD_BUTTON_XPATH);
+		if (!BuildButton.isVisible()) {
+			throw new RuntimeException("Build button is not visible");
+		} else {
+			BuildButton.click();
+		}
+	}
+	public static void verifyBuildPageButton(Page page, String buttonName) {
+		String BUILD_PAGE_BUTTON_XPATH = BUILD_PAGE_BUTTON.replace("{Button}", buttonName);
+		Locator button = page.getByTestId(BUILD_PAGE_BUTTON_XPATH);
+		if (!button.isVisible()) {
+			throw new RuntimeException("Get Started button for " + buttonName + " is not visible");
+		}else{
+			button.click();
+			if (buttonName.equalsIgnoreCase("drag") || buttonName.equalsIgnoreCase("code")) {
+				if (!page.locator(BUILD_PAGE_POPUP_XPATH).isVisible()) {
+					throw new RuntimeException("POP-Up is not showing after clicking on " + buttonName);
+				} else {
+					page.locator(BUILD_PAGE_POPUP_CLOSE_XPATH).click();
+				}
+			} else {
+				String currentUrl = page.url();
+				page.waitForLoadState(LoadState.DOMCONTENTLOADED);
+				if (!currentUrl.contains("prompt")) {
+					throw new RuntimeException("Browser Prompt page is not opened");
+				} else {
+					page.goBack();
+				}
+			}
+
+		}
+	}
+
+	public static void verifyBuildPageButtons(Page page, String buttonName) {
+		Locator button = page.locator(BUILD_PAGE_BROWSER_TEMPLATE_BUTTON_XPATH);
+		if (!button.isVisible()) {
+			throw new RuntimeException("Browser Template Button is not visible");
+		}else{
+			button.click();
+			String currentUrl = page.url();
+			page.waitForLoadState(LoadState.LOAD);
+			if (!currentUrl.contains("template")) {
+   				 throw new RuntimeException("Browser Template page is not opened");
+			} else {
+    			page.goBack(); 
+				}
+		}
+	}
+	public static void verifyTitleIsVisible(Page page, String titleName) {
+		Locator title = page.locator(BUILD_PAGE_TITLE_XPATH.replace("{title}", titleName));
+		if (!title.isVisible()) {
+			throw new RuntimeException(" the title with name " + titleName + " is not visible");
+		}
 	}
 
 	public static void logout(Page page) {

--- a/src/test/java/aicore/steps/app/CreateAppUsingDragAndDropSteps.java
+++ b/src/test/java/aicore/steps/app/CreateAppUsingDragAndDropSteps.java
@@ -128,6 +128,31 @@ public class CreateAppUsingDragAndDropSteps {
 		blocksPage.navigatesToHomePage();
 	}
 
+	@Given("User clicks on Build button")
+	public void user_navigates_to_build_button() {
+		homePage.clickOnBuildButton();
+	}
+
+	@And("User able to see the {string} button")
+	public void user_able_to_see_the_button(String buttonName) {
+		homePage.verifyBuildPageButtons(buttonName);
+	}
+
+	@Then("User able to see the following Buttons:")
+	public void user_able_to_see_the_buttons(io.cucumber.datatable.DataTable dataTable) {
+		List<String> buttons = dataTable.asList(String.class);
+		for (String buttonName : buttons) {
+			homePage.verifyBuildPageButton(buttonName);
+		}
+	}
+	@Then("User able to see the following Titles:")
+	public void user_able_to_see_the_titles(io.cucumber.datatable.DataTable dataTable) {
+		List<String> titles = dataTable.asList(String.class);
+		for (String titleName : titles) {
+			homePage.verifyTitleIsVisible(titleName);
+		}
+	}
+
 	@And("User searches {string} app in the app searchbox")
 	public void user_searches_app_in_the_app_searchbox(String appName) {
 		appPage.searchApp(appName);

--- a/src/test/resources/Features/app/Build.feature
+++ b/src/test/resources/Features/app/Build.feature
@@ -1,0 +1,22 @@
+@LoginWithAdmin
+Feature: Validate the Build Page
+
+  Scenario: Validate Build page title and buttons
+    Given User is on Home page
+    When User clicks on Build button
+    Then User able to see the following Titles:
+      | Empower your ideas with SEMOSS   |
+      | Experiment in our Playground™    |
+      | Simplify tasks with AI Conductor |
+      | Get started with our tools       |
+      | Drag and drop blocks             |
+      | Develop in code                  |
+      | Construct an agent               |
+      | Try these fan favorites          |
+      | BI                               |
+      | Terminal                         |
+    And User able to see the following Buttons:
+      | drag  |
+      | code  |
+      | agent |
+    And User able to see the "Browse Templates" button


### PR DESCRIPTION
## Overview
This PR introduces an automated test scenario to validate the Build Page UI elements for the SEMOSS platform when logged in as an Admin. The test ensures that all expected titles and buttons are present and visible to the user after navigating from the Home page.

## Feature File Reference
**Tag: @LoginWithAdmin**
## Feature: Validate the Build Page
### Scenario: Validate Build page title and buttons

**Given:** User is on Home page
**When:** User clicks on Build button
**Then:** User should see the following titles:
- Empower your ideas with SEMOSS
- Experiment in our Playground™
- Simplify tasks with AI Conductor
- Get started with our tools
- Drag and drop blocks
- Develop in code
- Construct an agent
- Try these fan favorites
- BI
- Terminal

**And:** User should see the following buttons:
- drag
- code
- agent

**And:** User should see the "Browse Templates" button