### PR TITLE
feat(issue-368): Add team member in Team

### DIFF
--- a/src/main/java/aicore/pages/TeamPermissionsSettingsPage.java
+++ b/src/main/java/aicore/pages/TeamPermissionsSettingsPage.java
@@ -30,6 +30,30 @@ public class TeamPermissionsSettingsPage {
     public void clickOnAddButton(String button) {
         TeamPermissionsSettingsUtils.clickOnAddButton(page, button);
     }
+    
+public void clickOnAddTeamButton(String button) {
+        TeamPermissionsSettingsUtils.clickOnAddTeamButton(page, button);
+    }
+
+    public void selectMemberFromList(String member) {
+        TeamPermissionsSettingsUtils.selectMemberFromList(page, member);
+    }
+
+    public void clickOnSaveMemberButton(String button) {
+        TeamPermissionsSettingsUtils.clickOnAddMemberButton(page, button);
+    }
+
+    public void validateToastMessage(String expectedMessage) {
+        TeamPermissionsSettingsUtils.validateToastMessage(page, expectedMessage);
+    }
+
+    public void checkMemberCard(String member) {
+        TeamPermissionsSettingsUtils.checkMemberCard(page, member);
+    }
+
+    public void checkMemberInList(String member) {
+        TeamPermissionsSettingsUtils.checkMemberInList(page, member);
+    }
 
     public String verifyName(String name) {
         return TeamPermissionsSettingsUtils.verifyName(page, name + " " + timestamp);

--- a/src/main/java/aicore/utils/settings/TeamPermissionsSettingsUtils.java
+++ b/src/main/java/aicore/utils/settings/TeamPermissionsSettingsUtils.java
@@ -11,6 +11,12 @@ public class TeamPermissionsSettingsUtils {
     private static final String TEAM_NAME_XPATH = "//legend/span[text()='Name*']/ancestor::div[contains(@class,'MuiInputBase-root')]//input";
     private static final String DESCRIPTION_XPATH = "//legend/span[normalize-space()='Description']/ancestor::div[contains(@class,'MuiInputBase-root')]//input";
     private static final String ADD_BUTTON_XPATH = "//button[.//span[normalize-space()='{buttonName}']]";
+    private static final String TEAM_BUTTON_XPATH = "//button//span[contains(text(), 'Add Members')]";
+    private static final String LIST_MEMBER_XPATH = "//*[contains(text(), '{Member}')]";
+    private static final String MEMBER_CARD_XPATH = "//span[contains(text(),'User ID:')]/div//span";
+    private static final String LIST_DROPDOWN= "ArrowDropDownIcon";
+    private static final String TOAST_MESSAGE_XPATH = "//div[contains(@class,'MuiAlert-message')]";
+    private static final String MEMBER_XPATH = "//div//p[contains(text(),'NATIVE ID: {member}')]";
     private static final String NAME_XPATH = "//p[normalize-space()='{Name}']";
     private static final String GENERATED_DESCRIPTION_XPATH = "//p[normalize-space()='{description}']";
 
@@ -34,6 +40,49 @@ public class TeamPermissionsSettingsUtils {
 
     public static void clickOnAddButton(Page page, String button) {
         page.click(ADD_BUTTON_XPATH.replace("{buttonName}", button));
+    }
+
+    public static void clickOnAddMemberButton(Page page, String button) {
+        page.click(ADD_BUTTON_XPATH.replace("{buttonName}", button));
+    }
+
+    public static void clickOnAddTeamButton(Page page, String button) {
+        page.click(TEAM_BUTTON_XPATH.replace("{buttonName}", button));
+    }
+
+    public static void selectMemberFromList(Page page, String member) {
+        Locator dropdownLocator = page.getByTestId(LIST_DROPDOWN);
+        AICorePageUtils.waitFor(dropdownLocator);
+        dropdownLocator.click();
+        Locator listMember = page.locator(LIST_MEMBER_XPATH.replace("{Member}", member));
+        AICorePageUtils.waitFor(listMember);
+        listMember.click();
+
+    }
+
+    public static void validateToastMessage(Page page, String expectedMessage) {
+        Locator toastMessage = page.locator(TOAST_MESSAGE_XPATH);
+        AICorePageUtils.waitFor(toastMessage);
+        String actualMessage = toastMessage.textContent().trim();
+        if (!actualMessage.equals(expectedMessage)) {
+            throw new AssertionError("Expected toast message: " + expectedMessage + ", but got: " + actualMessage);
+        }
+    }
+
+    public static void checkMemberCard(Page page, String member) {
+        Locator memberCard = page.locator(MEMBER_CARD_XPATH);
+        AICorePageUtils.waitFor(memberCard);
+        String actualMember = memberCard.textContent().trim();
+        if (!actualMember.equals(member)) {
+            throw new AssertionError("Expected member card: " + member + ", but got: " + actualMember);
+        }
+    }
+
+    public static void checkMemberInList(Page page, String member) {
+        Locator memberCard = page.locator(MEMBER_XPATH.replace("{member}", member));
+        if (!memberCard.isVisible()) {
+            throw new AssertionError("Expected " + member + " not present in the list: ");
+        }
     }
 
     public static String verifyName(Page page, String name) {

--- a/src/test/java/aicore/steps/TeamPermissionsSettingSteps.java
+++ b/src/test/java/aicore/steps/TeamPermissionsSettingSteps.java
@@ -38,6 +38,33 @@ public class TeamPermissionsSettingSteps {
     public void user_clicks_on_button_in_add_team_form(String button) {
         teamPermissionsSettings.clickOnAddButton(button);
     }
+    
+    @When("User clicks on {string} button in Add Team Page")
+    public void user_clicks_on_button_in_add_team_page(String button) {
+        teamPermissionsSettings.clickOnAddTeamButton(button);
+    }
+
+    @When("User selects {string} member from the list")
+    public void user_selects_member_from_the_list(String member) {
+        teamPermissionsSettings.selectMemberFromList(member);
+    }
+    @When("User sees {string} card in the Add Member form")
+    public void user_sees_card_in_the_add_member_form(String member) {
+        teamPermissionsSettings.checkMemberCard(member);
+    }
+
+    @When("User clicks on {string} button in Add Member form")
+    public void user_clicks_on_button_in_add_member_form(String button) {
+        teamPermissionsSettings.clickOnSaveMemberButton(button);
+    }
+    @Then("User sees the message {string} is displayed")
+    public void user_sees_the_message_is_displayed(String expectedMessage) {
+        teamPermissionsSettings.validateToastMessage(expectedMessage);
+    }
+    @Then("User can see the new member {string} added in the team member list")
+    public void user_can_see_the_new_member_added_in_the_team_member_list(String member) {
+        teamPermissionsSettings.checkMemberInList(member);
+    }
 
     @Then("User can see team name as {string} in the list")
     public void user_can_see_team_name_as_in_the_list(String name) {

--- a/src/test/resources/Features/settings/TeamUserPermissions.feature
+++ b/src/test/resources/Features/settings/TeamUserPermissions.feature
@@ -1,0 +1,20 @@
+Feature: Team Permissions - add User
+
+  Background: Team Permissions - Add team
+    Given User opens Main Menu
+    When User clicks on Open Settings
+    And User enable admin mode
+    And User clicks on 'Team Permissions' Card
+    And User clicks on "Add Team" button
+    And User selects type as "Custom" from Type dropdown
+    And User fills "Test Team" in Name field of Add Team form
+    And User fills Description as "Test Description" in Description field of Add Team form
+    And User clicks on "Add" button in Add Team form
+
+  Scenario: User add different user to the team
+    Given User clicks on "Add Member" button in Add Team Page
+    When User selects "editor" member from the list
+    Then User sees "editor" card in the Add Member form
+    And User clicks on "Save" button in Add Member form
+    And User sees the message "Successfully added member permissions" is displayed
+    And User can see the new member "editor" added in the team member list


### PR DESCRIPTION
### Description
This PR adds automated BDD scenarios for the Team Permissions feature, specifically enabling the creation of a custom team and adding an "editor" member to that team. The scenarios validate both the UI workflow and the expected outcomes when managing team permissions.

### Changes Made
- Implemented background steps for creating a custom team via the UI.
- Added scenario to add an "editor" member to the newly created team.
- Included assertions for success messages and member list updates.
- Ensured the workflow covers enabling admin mode and navigating relevant menus.
