### PR TITLE
[#370]:Test User add Engine for database, function , vector, storage catlog with different role access

### DIFF
--- a/src/main/java/aicore/pages/TeamPermissionsSettingsPage.java
+++ b/src/main/java/aicore/pages/TeamPermissionsSettingsPage.java
@@ -2,7 +2,6 @@ package aicore.pages;
 
 import com.microsoft.playwright.Page;
 
-import aicore.utils.settings.MyProfilePageUtils;
 import aicore.utils.settings.TeamPermissionsSettingsUtils;
 
 public class TeamPermissionsSettingsPage {
@@ -63,5 +62,23 @@ public void clickOnAddTeamButton(String button) {
 	public String validateDescription(String description) {
 		return TeamPermissionsSettingsUtils.validateDescription(page, description + " " + timestamp);
 	}	
+     // add engine to all catalog with different roles
+    public void userClickOnCreatedTeamName(String teamName,String timestamp) {
+        TeamPermissionsSettingsUtils.userClickOnCreatedTeamName(page, teamName,timestamp);
+     }
+    public void userClickOnAddEngineButton(){
+        TeamPermissionsSettingsUtils.userClickOnAddEngineButton(page);
+    }
+
+    public void userSelectEngineFromList(String catalogName,String timestamp) {
+        TeamPermissionsSettingsUtils.userSelectEngineFromList(page, catalogName,timestamp);
+     }
+    public boolean userSeeAddedEngineInTheList(String catalogName, String role) {
+        return TeamPermissionsSettingsUtils.userSeeAddedEngineInTheList(page, catalogName, role);
+     }
+    public void userSelectEngineAccessRole(String role) {
+        TeamPermissionsSettingsUtils.userSelectEngineAccessRole(page, role);
+     }
+
 
 }

--- a/src/main/java/aicore/utils/settings/TeamPermissionsSettingsUtils.java
+++ b/src/main/java/aicore/utils/settings/TeamPermissionsSettingsUtils.java
@@ -2,101 +2,135 @@ package aicore.utils.settings;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
 
 import aicore.utils.AICorePageUtils;
 
 public class TeamPermissionsSettingsUtils {
 
-    private static final String SELECT_TYPE_DROPDOWN_XPATH = "//legend/span[text()='Type*']/ancestor::div[contains(@class,'MuiInputBase-root')]//div[@role='combobox']";
-    private static final String TEAM_NAME_XPATH = "//legend/span[text()='Name*']/ancestor::div[contains(@class,'MuiInputBase-root')]//input";
-    private static final String DESCRIPTION_XPATH = "//legend/span[normalize-space()='Description']/ancestor::div[contains(@class,'MuiInputBase-root')]//input";
-    private static final String ADD_BUTTON_XPATH = "//button[.//span[normalize-space()='{buttonName}']]";
-    private static final String TEAM_BUTTON_XPATH = "//button//span[contains(text(), 'Add Members')]";
-    private static final String LIST_MEMBER_XPATH = "//*[contains(text(), '{Member}')]";
-    private static final String MEMBER_CARD_XPATH = "//span[contains(text(),'User ID:')]/div//span";
-    private static final String LIST_DROPDOWN= "ArrowDropDownIcon";
-    private static final String TOAST_MESSAGE_XPATH = "//div[contains(@class,'MuiAlert-message')]";
-    private static final String MEMBER_XPATH = "//div//p[contains(text(),'NATIVE ID: {member}')]";
-    private static final String NAME_XPATH = "//p[normalize-space()='{Name}']";
-    private static final String GENERATED_DESCRIPTION_XPATH = "//p[normalize-space()='{description}']";
+	private static final String SELECT_TYPE_DROPDOWN_XPATH = "//legend/span[text()='Type*']/ancestor::div[contains(@class,'MuiInputBase-root')]//div[@role='combobox']";
+	private static final String TEAM_NAME_XPATH = "//legend/span[text()='Name*']/ancestor::div[contains(@class,'MuiInputBase-root')]//input";
+	private static final String DESCRIPTION_XPATH = "//legend/span[normalize-space()='Description']/ancestor::div[contains(@class,'MuiInputBase-root')]//input";
+	private static final String ADD_BUTTON_XPATH = "//button[.//span[normalize-space()='{buttonName}']]";
+	private static final String TEAM_BUTTON_XPATH = "//button//span[contains(text(), 'Add Members')]";
+	private static final String LIST_MEMBER_XPATH = "//*[contains(text(), '{Member}')]";
+	private static final String MEMBER_CARD_XPATH = "//span[contains(text(),'User ID:')]/div//span";
+	private static final String LIST_DROPDOWN = "ArrowDropDownIcon";
+	private static final String TOAST_MESSAGE_XPATH = "//div[contains(@class,'MuiAlert-message')]";
+	private static final String MEMBER_XPATH = "//div//p[contains(text(),'NATIVE ID: {member}')]";
+	private static final String NAME_XPATH = "//p[normalize-space()='{Name}']";
+	private static final String GENERATED_DESCRIPTION_XPATH = "//p[normalize-space()='{description}']";
+	private static final String SELECT_ENGINE_ROLE_XPATH = "//input[@value='{role}']";
+	private static final String SELELCT_THE_ENGINE_DROPDOWN_XPATH = "//label[text()='Select Engine']";
+    private static final String  CLICK_ON_ADD_ENGINE_TEXT ="Add Engines";
 
-    public static void selectTypeFromDropdown(Page page, String type) {
-        Locator selectTypeFromDropdown = page.locator(SELECT_TYPE_DROPDOWN_XPATH);
-        AICorePageUtils.waitFor(selectTypeFromDropdown);
-        selectTypeFromDropdown.click();
-        page.waitForTimeout(300);
-        page.getByText(type).click();
-    }
+	public static void selectTypeFromDropdown(Page page, String type) {
+		Locator selectTypeFromDropdown = page.locator(SELECT_TYPE_DROPDOWN_XPATH);
+		AICorePageUtils.waitFor(selectTypeFromDropdown);
+		selectTypeFromDropdown.click();
+		page.waitForTimeout(300);
+		page.getByText(type).click();
+	}
 
-    public static void fillTeamName(Page page, String value) {
-        page.locator(TEAM_NAME_XPATH).isVisible();
-        page.locator(TEAM_NAME_XPATH).fill(value);
-    }
+	public static void fillTeamName(Page page, String value) {
+		page.locator(TEAM_NAME_XPATH).isVisible();
+		page.locator(TEAM_NAME_XPATH).fill(value);
+	}
 
-    public static void enterDescription(Page page, String description) {
-        page.locator(DESCRIPTION_XPATH).isVisible();
-        page.locator(DESCRIPTION_XPATH).fill(description);
-    }
+	public static void enterDescription(Page page, String description) {
+		page.locator(DESCRIPTION_XPATH).isVisible();
+		page.locator(DESCRIPTION_XPATH).fill(description);
+	}
 
-    public static void clickOnAddButton(Page page, String button) {
-        page.click(ADD_BUTTON_XPATH.replace("{buttonName}", button));
-    }
+	public static void clickOnAddButton(Page page, String button) {
+		page.click(ADD_BUTTON_XPATH.replace("{buttonName}", button));
+		page.reload(); // added because of stale element
+	}
 
-    public static void clickOnAddMemberButton(Page page, String button) {
-        page.click(ADD_BUTTON_XPATH.replace("{buttonName}", button));
-    }
+	public static void clickOnAddMemberButton(Page page, String button) {
+		page.click(ADD_BUTTON_XPATH.replace("{buttonName}", button));
+	}
 
-    public static void clickOnAddTeamButton(Page page, String button) {
-        page.click(TEAM_BUTTON_XPATH.replace("{buttonName}", button));
-    }
+	public static void clickOnAddTeamButton(Page page, String button) {
+		page.click(TEAM_BUTTON_XPATH.replace("{buttonName}", button));
+	}
 
-    public static void selectMemberFromList(Page page, String member) {
-        Locator dropdownLocator = page.getByTestId(LIST_DROPDOWN);
-        AICorePageUtils.waitFor(dropdownLocator);
-        dropdownLocator.click();
-        Locator listMember = page.locator(LIST_MEMBER_XPATH.replace("{Member}", member));
-        AICorePageUtils.waitFor(listMember);
-        listMember.click();
+	public static void selectMemberFromList(Page page, String member) {
+		Locator dropdownLocator = page.getByTestId(LIST_DROPDOWN);
+		AICorePageUtils.waitFor(dropdownLocator);
+		dropdownLocator.click();
+		Locator listMember = page.locator(LIST_MEMBER_XPATH.replace("{Member}", member));
+		AICorePageUtils.waitFor(listMember);
+		listMember.click();
 
-    }
+	}
 
-    public static void validateToastMessage(Page page, String expectedMessage) {
-        Locator toastMessage = page.locator(TOAST_MESSAGE_XPATH);
-        AICorePageUtils.waitFor(toastMessage);
-        String actualMessage = toastMessage.textContent().trim();
-        if (!actualMessage.equals(expectedMessage)) {
-            throw new AssertionError("Expected toast message: " + expectedMessage + ", but got: " + actualMessage);
-        }
-    }
+	public static void validateToastMessage(Page page, String expectedMessage) {
+		Locator toastMessage = page.locator(TOAST_MESSAGE_XPATH);
+		AICorePageUtils.waitFor(toastMessage);
+		String actualMessage = toastMessage.textContent().trim();
+		if (!actualMessage.equals(expectedMessage)) {
+			throw new AssertionError("Expected toast message: " + expectedMessage + ", but got: " + actualMessage);
+		}
+	}
 
-    public static void checkMemberCard(Page page, String member) {
-        Locator memberCard = page.locator(MEMBER_CARD_XPATH);
-        AICorePageUtils.waitFor(memberCard);
-        String actualMember = memberCard.textContent().trim();
-        if (!actualMember.equals(member)) {
-            throw new AssertionError("Expected member card: " + member + ", but got: " + actualMember);
-        }
-    }
+	public static void checkMemberCard(Page page, String member) {
+		Locator memberCard = page.locator(MEMBER_CARD_XPATH);
+		AICorePageUtils.waitFor(memberCard);
+		String actualMember = memberCard.textContent().trim();
+		if (!actualMember.equals(member)) {
+			throw new AssertionError("Expected member card: " + member + ", but got: " + actualMember);
+		}
+	}
 
-    public static void checkMemberInList(Page page, String member) {
-        Locator memberCard = page.locator(MEMBER_XPATH.replace("{member}", member));
-        if (!memberCard.isVisible()) {
-            throw new AssertionError("Expected " + member + " not present in the list: ");
-        }
-    }
+	public static void checkMemberInList(Page page, String member) {
+		Locator memberCard = page.locator(MEMBER_XPATH.replace("{member}", member));
+		if (!memberCard.isVisible()) {
+			throw new AssertionError("Expected " + member + " not present in the list: ");
+		}
+	}
 
-    public static String verifyName(Page page, String name) {
-        Locator actualName = page.locator(NAME_XPATH.replace("{Name}", name));
-        AICorePageUtils.waitFor(actualName);
-        actualName.scrollIntoViewIfNeeded();
-        return actualName.textContent().trim();
-    }
+	public static String verifyName(Page page, String name) {
+		Locator actualName = page.locator(NAME_XPATH.replace("{Name}", name));
+		AICorePageUtils.waitFor(actualName);
+		actualName.scrollIntoViewIfNeeded();
+		return actualName.textContent().trim();
+	}
 
-    public static String validateDescription(Page page, String description) {
-        Locator actualDescription = page.locator(GENERATED_DESCRIPTION_XPATH.replace("{description}", description));
-        AICorePageUtils.waitFor(actualDescription);
-        actualDescription.scrollIntoViewIfNeeded();
-        return actualDescription.textContent().trim();
-    }
+	public static String validateDescription(Page page, String description) {
+		Locator actualDescription = page.locator(GENERATED_DESCRIPTION_XPATH.replace("{description}", description));
+		AICorePageUtils.waitFor(actualDescription);
+		actualDescription.scrollIntoViewIfNeeded();
+		return actualDescription.textContent().trim();
+	}
+
+	// add engine to all catalog with different
+	public static void userClickOnCreatedTeamName(Page page, String teamName, String timestamp) {
+		page.getByText(teamName + " " + timestamp).click();
+	}
+
+	public static void userClickOnAddEngineButton(Page page) {
+		page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName(CLICK_ON_ADD_ENGINE_TEXT)).click();
+	}
+
+	public static void userSelectEngineFromList(Page page, String catalogName, String timestamp) {
+		Locator dropdownLocator = page.locator(SELELCT_THE_ENGINE_DROPDOWN_XPATH);
+		dropdownLocator.press("Enter");
+		dropdownLocator.fill(catalogName + " " + timestamp);
+		AICorePageUtils.waitFor(dropdownLocator);
+		page.getByText(catalogName).click();
+	}
+
+	public static void userSelectEngineAccessRole(Page page, String role) {
+		page.locator(SELECT_ENGINE_ROLE_XPATH.replace("{role}", role)).check();
+	}
+
+	public static boolean userSeeAddedEngineInTheList(Page page, String catalogName, String role) {
+		Locator addedEngine = page.getByRole(AriaRole.ROW, new Page.GetByRoleOptions().setName(catalogName))
+				.getByLabel(role);
+		addedEngine.check();
+		AICorePageUtils.waitFor(addedEngine);
+		return addedEngine.isVisible();
+	}
 
 }

--- a/src/test/java/aicore/steps/TeamPermissionsSettingSteps.java
+++ b/src/test/java/aicore/steps/TeamPermissionsSettingSteps.java
@@ -1,83 +1,113 @@
 package aicore.steps;
 
-import io.cucumber.java.en.Then;
-import io.cucumber.java.en.When;
-
 import org.junit.jupiter.api.Assertions;
 
 import aicore.hooks.SetupHooks;
 import aicore.pages.TeamPermissionsSettingsPage;
 import aicore.utils.CommonUtils;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class TeamPermissionsSettingSteps {
 
-    private TeamPermissionsSettingsPage teamPermissionsSettings;
-    private String timestamp;
+	private TeamPermissionsSettingsPage teamPermissionsSettings;
+	private String timestamp;
 
-    public TeamPermissionsSettingSteps() {
-        timestamp = CommonUtils.getTimeStampName();
-        teamPermissionsSettings = new TeamPermissionsSettingsPage(SetupHooks.getPage(), timestamp);
-    }
+	public TeamPermissionsSettingSteps() {
+		timestamp = CommonUtils.getTimeStampName();
+		teamPermissionsSettings = new TeamPermissionsSettingsPage(SetupHooks.getPage(), timestamp);
+	}
 
-    @When("User selects type as {string} from Type dropdown")
-    public void user_selects_type_as_from_type_dropdown(String type) {
-        teamPermissionsSettings.selectTypeFromDropdown(type);
-    }
+	@When("User selects type as {string} from Type dropdown")
+	public void user_selects_type_as_from_type_dropdown(String type) {
+		teamPermissionsSettings.selectTypeFromDropdown(type);
+	}
 
-    @When("User fills {string} in Name field of Add Team form")
-    public void user_fills_in_name_field_of_add_team_form(String string) {
-        teamPermissionsSettings.fillTeamName(string + " " + timestamp);
-    }
+	@When("User fills {string} in Name field of Add Team form")
+	public void user_fills_in_name_field_of_add_team_form(String string) {
+		teamPermissionsSettings.fillTeamName(string + " " + timestamp);
+	}
 
-    @When("User fills Description as {string} in Description field of Add Team form")
-    public void user_fills_description_as_in_description_field_of_add_team_form(String description) {
-        teamPermissionsSettings.enterDescription(description + " " + timestamp);
-    }
+	@When("User fills Description as {string} in Description field of Add Team form")
+	public void user_fills_description_as_in_description_field_of_add_team_form(String description) {
+		teamPermissionsSettings.enterDescription(description + " " + timestamp);
+	}
 
-    @When("User clicks on {string} button in Add Team form")
-    public void user_clicks_on_button_in_add_team_form(String button) {
-        teamPermissionsSettings.clickOnAddButton(button);
-    }
-    
-    @When("User clicks on {string} button in Add Team Page")
-    public void user_clicks_on_button_in_add_team_page(String button) {
-        teamPermissionsSettings.clickOnAddTeamButton(button);
-    }
+	@When("User clicks on {string} button in Add Team form")
+	public void user_clicks_on_button_in_add_team_form(String button) {
+		teamPermissionsSettings.clickOnAddButton(button);
+	}
 
-    @When("User selects {string} member from the list")
-    public void user_selects_member_from_the_list(String member) {
-        teamPermissionsSettings.selectMemberFromList(member);
-    }
-    @When("User sees {string} card in the Add Member form")
-    public void user_sees_card_in_the_add_member_form(String member) {
-        teamPermissionsSettings.checkMemberCard(member);
-    }
+	@When("User clicks on {string} button in Add Team Page")
+	public void user_clicks_on_button_in_add_team_page(String button) {
+		teamPermissionsSettings.clickOnAddTeamButton(button);
+	}
 
-    @When("User clicks on {string} button in Add Member form")
-    public void user_clicks_on_button_in_add_member_form(String button) {
-        teamPermissionsSettings.clickOnSaveMemberButton(button);
-    }
-    @Then("User sees the message {string} is displayed")
-    public void user_sees_the_message_is_displayed(String expectedMessage) {
-        teamPermissionsSettings.validateToastMessage(expectedMessage);
-    }
-    @Then("User can see the new member {string} added in the team member list")
-    public void user_can_see_the_new_member_added_in_the_team_member_list(String member) {
-        teamPermissionsSettings.checkMemberInList(member);
-    }
+	@When("User selects {string} member from the list")
+	public void user_selects_member_from_the_list(String member) {
+		teamPermissionsSettings.selectMemberFromList(member);
+	}
 
-    @Then("User can see team name as {string} in the list")
-    public void user_can_see_team_name_as_in_the_list(String name) {
-        String actualName = teamPermissionsSettings.verifyName(name);
-        String expectedName = name + " " + timestamp;
-        Assertions.assertEquals(expectedName, actualName);
-    }
+	@When("User sees {string} card in the Add Member form")
+	public void user_sees_card_in_the_add_member_form(String member) {
+		teamPermissionsSettings.checkMemberCard(member);
+	}
 
-    @Then("User can see description as {string} in the list")
-    public void user_can_see_description_as_in_the_list(String description) {
-        String actualDescription = teamPermissionsSettings.validateDescription(description);
-        String expectedDesc = description + " " + timestamp;
-        Assertions.assertEquals(expectedDesc, actualDescription);
-    }
+	@When("User clicks on {string} button in Add Member form")
+	public void user_clicks_on_button_in_add_member_form(String button) {
+		teamPermissionsSettings.clickOnSaveMemberButton(button);
+	}
+
+	@Then("User sees the message {string} is displayed")
+	public void user_sees_the_message_is_displayed(String expectedMessage) {
+		teamPermissionsSettings.validateToastMessage(expectedMessage);
+	}
+
+	@Then("User can see the new member {string} added in the team member list")
+	public void user_can_see_the_new_member_added_in_the_team_member_list(String member) {
+		teamPermissionsSettings.checkMemberInList(member);
+	}
+
+	@Then("User can see team name as {string} in the list")
+	public void user_can_see_team_name_as_in_the_list(String name) {
+		String actualName = teamPermissionsSettings.verifyName(name);
+		String expectedName = name + " " + timestamp;
+		Assertions.assertEquals(expectedName, actualName);
+	}
+
+	@Then("User can see description as {string} in the list")
+	public void user_can_see_description_as_in_the_list(String description) {
+		String actualDescription = teamPermissionsSettings.validateDescription(description);
+		String expectedDesc = description + " " + timestamp;
+		Assertions.assertEquals(expectedDesc, actualDescription);
+	}
+
+	// add engine to all catalog with different roles
+	@And("User clicks on the team name {string} in the list")
+	public void user_clicks_on_the_team_name_in_the_list(String teamName) {
+		teamPermissionsSettings.userClickOnCreatedTeamName(teamName, timestamp);
+	}
+
+	@And("User clicks on {string} button in Team Permission page")
+	public void user_clicks_on_button_in_team_permission_page(String addEngine) {
+		teamPermissionsSettings.userClickOnAddEngineButton();
+	}
+
+	@And("User select the {string} in the Engine field of Add Engine form")
+	public void user_select_the_in_the_engine_field_of_add_engine_form(String databaseName) {
+		teamPermissionsSettings.userSelectEngineFromList(databaseName, timestamp);
+	}
+
+	@And("User select the engine access as {string}")
+	public void user_select_the_engine_access_as(String role) {
+		teamPermissionsSettings.userSelectEngineAccessRole(role);
+	}
+
+	@And("User see the added {string} in the engine list with access as {string}")
+	public void user_sees_the_with_role_added_in_the_list(String catalogName, String role) {
+		boolean isEnginePresent = teamPermissionsSettings.userSeeAddedEngineInTheList(catalogName, role);
+		Assertions.assertTrue(isEnginePresent, "Engine with the specified role is not present in the list.");
+	}
 
 }

--- a/src/test/resources/Features/settings/TeamPermissionAddEngine.feature
+++ b/src/test/resources/Features/settings/TeamPermissionAddEngine.feature
@@ -1,0 +1,157 @@
+Feature: Add Engine for Team Permission
+
+  Background: Team Permissions - Add team
+    Given User opens Main Menu
+    When User clicks on Open Settings
+    And User enable admin mode
+    And User clicks on 'Team Permissions' Card
+    And User clicks on 'Add Team' button
+    And User selects type as 'Custom' from Type dropdown
+    And User fills 'Test Team' in Name field of Add Team form
+    And User fills Description as 'Test Description' in Description field of Add Team form
+    And User clicks on 'Add' button in Add Team form
+
+	@DeleteTestCatalog
+    Scenario Outline: Add Engine for Database Users role
+    Given User opens Main Menu
+    And User clicks on Open Database
+    When User clicks on Add Database
+    Then User selects database 'ZIP'
+    And User uploads database file 'Database/TestDatabase.zip'
+    And User clicks on Create Database button
+    And User searches the 'TestDatabase' in the database Catalog searchbox
+    And User sees the database name 'TestDatabase' in the database catalog
+    And User clicks on the database name 'TestDatabase' in the database catalog
+    And User clicks On Copy Catalog ID
+    Given User opens Main Menu
+    When User clicks on Open Settings
+    And User enable admin mode
+    And User clicks on 'Team Permissions' Card
+    Then User can see team name as "Test Team" in the list
+    And User clicks on the team name 'Test Team' in the list
+    When User clicks on 'Add Engine' button in Team Permission page 
+    And User select the 'TestDatabase' in the Engine field of Add Engine form
+    And User select the engine access as '<Role>'
+    And User clicks on save button
+    Then User sees the message 'Successfully added engine permission' is displayed 
+    And User see the added 'TestDatabase' in the engine list with access as '<Role>'
+
+    Examples:
+      | Role        |
+      | Author      |
+      | Editor      |
+      | Read-Only   |
+
+    @DeleteTestCatalog
+    Scenario Outline: Add Engine for Function Users role
+    Given User opens Main Menu
+    When User clicks on Open Function
+    And User clicks on Add Function
+    And User selects function 'ZIP'
+    And User uploads function file 'Function/weatherFunctionTest.zip'
+    And User clicks on Create Function button
+    Then User sees the function name 'WeatherFunctionTest' in the function catalog
+    And User searches the 'WeatherFunctionTest' in the function Catalog searchbox
+    And User selects the 'WeatherFunctionTest' from the function catalog
+    And User clicks On Copy Catalog ID
+    Given User opens Main Menu
+    When User clicks on Open Settings
+    And User enable admin mode
+    And User clicks on 'Team Permissions' Card
+    Then User can see team name as "Test Team" in the list
+    And User clicks on the team name 'Test Team' in the list
+    When User clicks on 'Add Engine' button in Team Permission page 
+    And User select the 'WeatherFunctionTest' in the Engine field of Add Engine form
+    And User select the engine access as '<Role>'
+    And User clicks on save button
+    Then User sees the message 'Successfully added engine permission' is displayed 
+    And User see the added 'WeatherFunctionTest' in the engine list with access as '<Role>'
+
+    Examples:
+      | Role        |
+      | Author      |
+      | Editor      |
+      | Read-Only   |
+      
+    @DeleteTestCatalog
+    Scenario Outline: Add Engine for Storage Users role
+    Given User is on Home page
+    When User opens Main Menu
+    And User clicks on Open Storage engine
+    When User clicks on Add Storage button
+    And User selects 'Amazon S3' storage
+    And User enters storage Catalog name as 'Amazon S3 Storage'
+    And User enters Region as 'India'
+    And User enters Bucket as 'BucketTest'
+    And User enters Access Key as 'Test123'
+    And User enters Secret Key as 'Test123'
+    And User clicks on Create Storage button
+    Then User can see create storage success toast message as 'Successfully added to catalog storage'
+    And User clicks On Copy Catalog ID
+    Given User opens Main Menu
+    When User clicks on Open Settings
+    And User enable admin mode
+    And User clicks on 'Team Permissions' Card
+    Then User can see team name as "Test Team" in the list
+    And User clicks on the team name 'Test Team' in the list
+    When User clicks on 'Add Engine' button in Team Permission page 
+    And User select the 'Amazon S3 Storage' in the Engine field of Add Engine form
+    And User select the engine access as '<Role>'
+    And User clicks on save button
+    Then User sees the message 'Successfully added engine permission' is displayed 
+    And User see the added 'Amazon S3 Storage' in the engine list with access as '<Role>'
+
+    Examples:
+      | Role        |
+      | Author      |
+      | Editor      |
+      | Read-Only   |
+
+ @DeleteTestCatalog
+    Scenario Outline: Add Engine for Vector Users role
+    Given User is on Home page
+    When User opens Main Menu
+    And User clicks on Open Model
+    And User clicks on Add Model
+    And User selects 'GPT-3.5'
+    And User enters Catalog name as 'Catalog'
+    And User enters open AI Key as 'Test@1234'
+    And User enters var name as 'Variable1'
+    And User clicks on Create Model button
+    And User clicks On Copy Catalog ID
+    When User clicks on Edit button
+    And User add tags 'embeddings' and presses Enter
+    And User clicks on Submit button
+    Given User is on Home page
+    When User opens Main Menu
+    And User clicks on Open Vector
+    When User clicks on Add Vector button
+    And User selects 'FAISS' connection
+    And User enters vector database Catalog name as 'FAISS Vector DB01'
+    And User selects 'Catalog' from Embedder field
+    And User selects 'Token' from Chunking Strategy field
+    And User enters value of Content Length as '510'
+    And User enters value of Content Overlap as '17'
+    And User clicks on Create Vector button
+    Then User can see vector database created success toast message as 'Successfully added vector database to catalog'
+    And User can see the Vector title as 'FAISS Vector DB01'
+    And User clicks On Copy Catalog ID
+    Given User opens Main Menu
+    When User clicks on Open Settings
+    And User enable admin mode
+    And User clicks on 'Team Permissions' Card
+    Then User can see team name as "Test Team" in the list
+    And User clicks on the team name 'Test Team' in the list
+    When User clicks on 'Add Engine' button in Team Permission page 
+    And User select the 'FAISS Vector DB01' in the Engine field of Add Engine form
+    And User select the engine access as '<Role>'
+    And User clicks on save button
+    Then User sees the message 'Successfully added engine permission' is displayed 
+    And User see the added 'FAISS Vector DB01' in the engine list with access as '<Role>'
+
+    Examples:
+      | Role        |
+      | Author      |
+      | Editor      |
+      | Read-Only   |
+      


### PR DESCRIPTION
> Description

User creates a database, then creates a team and navigates to Team Permissions. In Team Permissions, the user adds an engine, selects the created database, assigns access (Author, Editor, or Read Only), and clicks the Save button. After saving, the user validates that the engine is added with the correct name and access role. The same implementation is done for Storage, Vector, and Function.

## How to Test
1.Login as author user 
2.Create any catalog eg. database
3.Navigate to Setting and turn on the admin
4.Select the Team permission
5.Click on add engine
6.Selelct the created catalog 
7.Click on save button
8.Validate Engine is added into team permission page with respective added name and role
