### PR TITLE
feat(591): Playground configuration panel  model validation

### DIFF
--- a/src/main/java/aicore/pages/PlaygroundPage.java
+++ b/src/main/java/aicore/pages/PlaygroundPage.java
@@ -31,6 +31,30 @@ public class PlaygroundPage {
         PlaygroundPageUtils.clickOnOpenConfigurationMenuButton(page, buttonName);
     }
 
+    public void verifyModelCatalogDropdownPresent(String modelName) {
+        PlaygroundPageUtils.verifyModelCatalogDropdownPresent(page, modelName);
+    }
+
+    public void clickOnModelCatalogDropdown() {
+        PlaygroundPageUtils.clickOnModelCatalogDropdown(page);
+    }
+
+    public void verifyModelIsChecked(String modelName) {
+        PlaygroundPageUtils.verifyModelIsChecked(page, modelName);
+    }
+
+    public void searchModelInSearchbox(String modelName) {
+        PlaygroundPageUtils.searchModelInSearchbox(page, modelName);
+    }
+
+    public void verifyModelVisibleInDropdown(String modelName) {
+        PlaygroundPageUtils.verifyModelVisibleInDropdown(page, modelName);
+    }
+
+    public void selectModelFromDropdown(String modelName) {
+        PlaygroundPageUtils.selectModelFromDropdown(page, modelName);
+    }
+
     public void verifyConfigurationMenuIsOpened() {
         PlaygroundPageUtils.verifyConfigurationMenuIsOpened(page);
     }

--- a/src/main/java/aicore/utils/PlaygroundPageUtils.java
+++ b/src/main/java/aicore/utils/PlaygroundPageUtils.java
@@ -9,6 +9,11 @@ public class PlaygroundPageUtils {
     private static final String PLAYGROUND_APP_BUTTON_XPATH = "//span[text()='Experiment in our Playground™']/../../..//a";
     private static final String PROMPT_THE_MODEL_BUTTON_LABEL = "Prompt the Model";
     private static final String CONFIGURATION_MENU_XPATH = "//form";
+    private static final String MODEL_CATALOG_DROPDOWN = "//div//label[text()='Model']//following-sibling::button//span";
+    private static final String MODEL_CATALOG_DROPDOWN_CHECKED = "//div[@role='group']//div//span[contains(text(),'{catalogName}')]/../../*[1]";
+    private static final String MODEL_CATALOG_SEARCH_INPUT = "//div/div/input[@placeholder='Search']";
+    private static final String MODEL_ITEM_BY_NAME = "//div[@data-slot='command-group']//div//div//div//span[contains(text(),'{modelName}')]";
+    private static final String MODEL_CHECKBOX_BY_NAME = ".//div[contains(@class,'model-item') and normalize-space(text())='{MODEL}']//input[@type='checkbox']";
 
     public static void clickOnPlaygroundAppButton(Page page) {
         Locator anchor = page.locator(PLAYGROUND_APP_BUTTON_XPATH);
@@ -37,7 +42,69 @@ public class PlaygroundPageUtils {
 
     public static void clickOnOpenConfigurationMenuButton(Page page, String buttonName) {
         Locator button = page.getByLabel(buttonName);
-        button.click();
+        if(button.isEnabled()) {
+            button.click(); 
+        }else {
+            throw new AssertionError("The button '" + buttonName + "' is disabled and cannot be clicked.");
+        }
+    }
+
+    public static void verifyModelCatalogDropdownPresent(Page page, String modelName) {
+        Locator dropdown = page.locator(MODEL_CATALOG_DROPDOWN);
+        AICorePageUtils.waitFor(dropdown);
+        String dropdownText = dropdown.textContent();
+        if (!dropdown.isVisible() && (dropdownText == null || dropdownText.isEmpty())) {
+            throw new AssertionError("Model catalog text not visible");
+        }
+    }
+
+    public static void clickOnModelCatalogDropdown(Page page) {
+        Locator dropdown = page.locator(MODEL_CATALOG_DROPDOWN);
+        AICorePageUtils.waitFor(dropdown);
+        try {
+            dropdown.click();
+        } catch (Exception e) {
+            dropdown.click(new Locator.ClickOptions().setForce(true));
+        }
+    }
+
+    public static void verifyModelIsChecked(Page page, String modelName) {
+        Locator dropdown = page.locator(MODEL_CATALOG_DROPDOWN);
+        AICorePageUtils.waitFor(dropdown);
+        String dropdownText = dropdown.textContent();
+        if(!(modelName.equals("default")) && dropdownText.contains(modelName)) {
+        Locator checkbox = page.locator(MODEL_CATALOG_DROPDOWN_CHECKED.replace("{catalogName}", modelName));
+        AICorePageUtils.waitFor(checkbox);
+        if (!checkbox.isVisible()){
+            throw new AssertionError("Model with partial name'" + modelName + "' is not checked in dropdown");
+        }
+    }
+    }
+
+    public static void searchModelInSearchbox(Page page, String modelName) {
+        Locator input = page.locator(MODEL_CATALOG_SEARCH_INPUT);
+        AICorePageUtils.waitFor(input);
+        input.fill(modelName);
+        page.waitForTimeout(300);
+    }
+
+    public static void verifyModelVisibleInDropdown(Page page, String modelName) {
+        Locator model = page.locator(MODEL_ITEM_BY_NAME.replace("{modelName}", modelName));
+        AICorePageUtils.waitFor(model);
+        if (!model.isVisible()) {
+            throw new AssertionError("Model '" + modelName + "' not visible in dropdown");
+        }
+    }
+
+    public static void selectModelFromDropdown(Page page, String modelName) {
+        Locator model = page.locator(MODEL_ITEM_BY_NAME.replace("{modelName}", modelName));
+        AICorePageUtils.waitFor(model);
+        try {
+            model.click();
+        } catch (Exception e) {
+            model.click(new Locator.ClickOptions().setForce(true));
+        }
+        page.waitForTimeout(300);
     }
 
     public static void verifyConfigurationMenuIsOpened(Page page) {

--- a/src/test/java/aicore/steps/PlaygroundSteps.java
+++ b/src/test/java/aicore/steps/PlaygroundSteps.java
@@ -2,8 +2,6 @@ package aicore.steps;
 
 import java.util.List;
 
-import org.junit.platform.commons.function.Try;
-
 import aicore.hooks.SetupHooks;
 import aicore.pages.PlaygroundPage;
 import io.cucumber.datatable.DataTable;
@@ -45,6 +43,36 @@ public class PlaygroundSteps {
     @And("User clicks on the {string} button")
     public void user_Clicks_On_The_Open_Configuration_Menu_Button(String buttonName) {
         playgroundPage.clickOnOpenConfigurationMenuButton(buttonName);
+    }
+
+     @Then("User verify the model catalog dropdown is present with default model with {string} name")
+    public void user_Verify_The_Model_Catalog_Dropdown_Is_Present_With_Default_Model_With(String modelName) {
+        playgroundPage.verifyModelCatalogDropdownPresent(modelName);
+    }
+
+    @When("User clicks on the Model dropdown")
+    public void user_Clicks_On_The_Model_Dropdown() {
+        playgroundPage.clickOnModelCatalogDropdown();
+    }
+
+    @Then("User verify {string} model should be checked in the model catalog dropdown")
+    public void user_Verify_The_Model_Should_Be_Checked_In_The_Model_Catalog_Dropdown(String modelName) {
+        playgroundPage.verifyModelIsChecked(modelName);
+    }
+
+    @When("User searches the {string} configuration tab in the model catalog searchbox")
+    public void user_Searches_The_Configuration_Tab_In_The_Model_Catalog_Searchbox(String modelName) {
+        playgroundPage.searchModelInSearchbox(modelName);
+    }
+
+    @Then("User should see the {string} in the model catalog dropdown")
+    public void user_Should_See_The_In_The_Model_Catalog_Dropdown(String modelName) {
+        playgroundPage.verifyModelVisibleInDropdown(modelName);
+    }
+
+    @When("User selects the {string} from the model catalog dropdown")
+    public void user_Selects_The_From_The_Model_Catalog_Dropdown(String modelName) {
+        playgroundPage.selectModelFromDropdown(modelName);
     }
 
     @Then("User verifies that the {string} button is {string}")

--- a/src/test/resources/Features/playground/PlaygroundConfiguration.feature
+++ b/src/test/resources/Features/playground/PlaygroundConfiguration.feature
@@ -1,0 +1,39 @@
+Feature: Playground Home model to verify configuration tab
+
+  @LoginWithAdmin @Regression
+  Scenario Outline: Validate Playground Configuration tab for Model - add model
+    Given User is on Home page
+    When User opens Main Menu
+    And User clicks on Open Model
+    And User clicks on Add Model
+    And User selects '<MODEL_TYPE>' type
+    And User selects '<MODEL_NAME>'
+    And User enters Catalog Name as '<CATLOG_NAME>'
+    And User enters Open AI Key as '<KEY>'
+    And User clicks on Create Model button
+    And User can see a toast message as '<TOAST_MESSAGE>'
+    And User clicks on Edit button
+    And User add tags '<TAGS>' and presses Enter
+    And User clicks on Submit button
+    And User clicks on Copy Catalog ID
+    Then User can see the Model title as '<CATLOG_NAME>'
+    Examples: 
+      | MODEL_TYPE | MODEL_NAME    | CATLOG_NAME | KEY       | TOAST_MESSAGE                     | TAGS            |
+      | OpenAI     | GPT 3.5 Turbo | Model1      | Test@1234 | Successfully added LLM to catalog | text-generation |
+      | OpenAI     | GPT 3.5 Turbo | Model2      | Test@1234 | Successfully added LLM to catalog | text-generation |
+
+  @LoginWithAdmin @Regression @DeleteTestCatalog
+  Scenario: Validate Playground Configuration tab for Model - add/search Model
+    Given User is on Home page
+    When User clicks on Build button
+    And User clicks on Try it out hyperlink for Experiment in our Playground
+    And User clicks on the "Open Configuration Menu" button
+    Then User verify the model catalog dropdown is present with default model with 'Model' name
+    When User clicks on the Model dropdown
+    Then User verify "default" model should be checked in the model catalog dropdown
+    And User searches the 'Model2' configuration tab in the model catalog searchbox
+    Then User should see the 'Model2' in the model catalog dropdown
+    When User selects the 'Model2' from the model catalog dropdown
+    And User clicks on the Model dropdown
+    Then User verify "Model2" model should be checked in the model catalog dropdown
+    


### PR DESCRIPTION
## Description
This PR adds comprehensive end-to-end automated tests for the Playground Home model configuration tab, focusing on the following user journeys:

- Adding a new model
- Editing a model with tags and verifying catalog title
- Searching for models in the catalog dropdown
- Verifying model selection and presence in the configuration tab

**Related Feature(s)**

**Feature: Playground Home model to verify configuration tab**


## Scenarios Covered
1️⃣ **Add Model and Verify in Configuration Tab**

**Automated coverage for model creation with:**

- Model type and name selection
- Catalog Name and OpenAI Key input
- Toast message assertion for successful addition
- Editing model to add tags
- Catalog ID copy functionality
- Catalog title verification post-creation


**Parameterized to run for different model/catalog/tag values**

2️⃣ **Search and Select Model in Configuration Tab**

**Builds a Playground “Try it out” scenario:**

- Model catalog dropdown presence and default selection
- Searching within the dropdown for ‘Model2’
- Model selection updating currently checked/active model in the dropdown
- Assertions on selection state change for checked models