### PR TITLE
feat(playground): Verify MCP Tool in playground

### DIFF
--- a/src/main/java/aicore/pages/PlaygroundPage.java
+++ b/src/main/java/aicore/pages/PlaygroundPage.java
@@ -30,6 +30,38 @@ public class PlaygroundPage {
     public void clickOnOpenConfigurationMenuButton(String buttonName) {
         PlaygroundPageUtils.clickOnOpenConfigurationMenuButton(page, buttonName);
     }
+    public void clickOnMCPDropdown() {
+        PlaygroundPageUtils.clickOnMCPDropdown(page);
+    }
+
+    public void saveAddedMCPList() {
+        PlaygroundPageUtils.saveAddedMCPList(page);
+    }
+
+    public void clickOverifyMCPAppVisibleInAvailableTools(String modelName) {
+        PlaygroundPageUtils.clickOverifyMCPAppVisibleInAvailableTools(page, modelName);
+
+    }
+
+    public void verifyAddedMCPAppSelectedList(String modelName) {
+        PlaygroundPageUtils.verifyAddedMCPAppSelectedList(page, modelName);
+    }
+
+    public void verifyAddedMCPModelMCPSection(String modelName) {
+        PlaygroundPageUtils.verifyAddedMCPModelMCPSection(page, modelName);
+    }
+
+    public void deleteAddedMCPModelMCPSection(String modelName) {
+        PlaygroundPageUtils.deleteAddedMCPModelMCPSection(page, modelName);
+    }
+
+    public void verifyMCPModelRemovedMCPSection(String modelName) {
+        PlaygroundPageUtils.verifyMCPModelRemovedMCPSection(page, modelName);
+    }
+
+    public void searchAndSelectMCPModel(String modelName) {
+        PlaygroundPageUtils.searchAndSelectMCPModel(page, modelName);
+    }
 
     public void verifyModelCatalogDropdownPresent(String modelName) {
         PlaygroundPageUtils.verifyModelCatalogDropdownPresent(page, modelName);

--- a/src/test/java/aicore/steps/AddModelSteps.java
+++ b/src/test/java/aicore/steps/AddModelSteps.java
@@ -49,6 +49,29 @@ public class AddModelSteps {
 		openModelPage.clickOnGroupTab(tabName);
 	}
 
+	@And("User add {string} models with details {string} {string} {string} {string} {string}")
+    public void user_add_models_with_details(String index, String modelType, String modelName, String catalogName, String apiKey, String tags) {
+		int modelCount = Integer.parseInt(index);
+		for (int i = 0; i < modelCount; i++) {
+			openModelPage.selectModelType(modelType);
+			openModelPage.selectModel(modelName);
+			openModelPage.enterCatalogName(catalogName+""+(i+1));
+			openModelPage.enterOpenAIKey(apiKey);
+			openModelPage.clickOnCreateModelButton();
+			viewCatalogPage.clickEditIcon();
+			String[] tagsArray = tags.split(", ");
+			for (String tag : tagsArray) {
+				viewCatalogPage.enterTagName(tag);
+			}
+			viewCatalogPage.clickOnSubmit();
+			if(i < modelCount -1) {
+			homePage.openMainMenu();
+			homePage.clickOnOpenModel();
+			openModelPage.clickAddModelButton();
+			}
+		}
+	}
+
 	@And("User selects {string} type")
 	public void user_selects_type(String model) {
 		openModelPage.selectModelType(model);
@@ -286,7 +309,7 @@ public class AddModelSteps {
 		viewCatalogPage.clickOnClose();
 	}
 
-//Edit SMSS
+	// Edit SMSS
 
 	@And("User clicks on Edit SMSS button")
 	public void user_clicks_on_edit_smss_button() {
@@ -312,14 +335,14 @@ public class AddModelSteps {
 	public void user_can_see_updated_value_in_field_as(String field, String newValue) {
 		String fullText = null;
 		switch (field) {
-		case "VAR_NAME":
-			fullText = openModelPage.verifyVarNameInSMSS();
-			break;
-		case "KEEP_CONVERSATION_HISTORY":
-			fullText = openModelPage.verifyKeepConversationHistoryValueInSMSS(field);
-			break;
-		default:
-			System.out.println("Invalid field name " + field);
+			case "VAR_NAME":
+				fullText = openModelPage.verifyVarNameInSMSS();
+				break;
+			case "KEEP_CONVERSATION_HISTORY":
+				fullText = openModelPage.verifyKeepConversationHistoryValueInSMSS(field);
+				break;
+			default:
+				System.out.println("Invalid field name " + field);
 		}
 		String actualVarName = CommonUtils.splitTrimValue(fullText, field);
 		assertEquals(actualVarName, newValue);
@@ -438,16 +461,20 @@ public class AddModelSteps {
 			}
 			// Field-specific validation logic
 			switch (fieldName) {
-//			case "ENDPOINT":
-//				Assertions.assertEquals(expectedValue, fullText, "Field validation failed for '" + fieldName + "'");
-//				break;
-			case "INIT_MODEL_ENGINE":
-				Assertions.assertTrue(actualValue.contains(expectedValue), "Field validation failed for '" + fieldName
-						+ "' ==> expected partial text: <" + expectedValue + "> but was: <" + actualValue + ">");
-				break;
-			default:
-				Assertions.assertEquals(expectedValue, actualValue, "Field validation failed for '" + fieldName + "'");
-				break;
+				// case "ENDPOINT":
+				// Assertions.assertEquals(expectedValue, fullText, "Field validation failed for
+				// '" + fieldName + "'");
+				// break;
+				case "INIT_MODEL_ENGINE":
+					Assertions.assertTrue(actualValue.contains(expectedValue),
+							"Field validation failed for '" + fieldName
+									+ "' ==> expected partial text: <" + expectedValue + "> but was: <" + actualValue
+									+ ">");
+					break;
+				default:
+					Assertions.assertEquals(expectedValue, actualValue,
+							"Field validation failed for '" + fieldName + "'");
+					break;
 			}
 		}
 	}

--- a/src/test/java/aicore/steps/PlaygroundSteps.java
+++ b/src/test/java/aicore/steps/PlaygroundSteps.java
@@ -45,6 +45,46 @@ public class PlaygroundSteps {
         playgroundPage.clickOnOpenConfigurationMenuButton(buttonName);
     }
 
+    @When("User clicks on the MCP dropdown")
+    public void user_Clicks_On_The_MCP_Dropdown() {
+        playgroundPage.clickOnMCPDropdown();
+    }
+
+    @And("User should see and select the {string} in the MCP availale tools")
+    public void user_Should_See_And_Select_The_In_The_MCP_Availale_Tools(String appName) {
+        playgroundPage.clickOverifyMCPAppVisibleInAvailableTools(appName);
+    }
+
+    @And("User verify added {string} is updated in selected list")
+    public void user_Verify_Added_Is_Updated_In_Selected_List(String appName) {
+        playgroundPage.verifyAddedMCPAppSelectedList(appName);
+    }
+
+    @When("User saves the added MCP list")
+    public void user_Saves_The_Added_MCP_List() {
+        playgroundPage.saveAddedMCPList();
+    }
+
+    @Then("User verify the added {string} is displayed in MCP section")
+    public void user_Verify_The_Added_Is_Displayed_In_MCP_Section(String appName) {
+        playgroundPage.verifyAddedMCPModelMCPSection(appName);
+    }
+
+    @When("User deletes the added {string} from MCP section")
+    public void user_Deletes_The_Added_From_MCP_Section(String appName) {
+        playgroundPage.deleteAddedMCPModelMCPSection(appName);
+    }
+
+    @Then("User verify the {string} is removed from MCP section")
+    public void user_Verify_The_Is_Removed_From_MCP_Section(String appName) {
+        playgroundPage.verifyMCPModelRemovedMCPSection(appName);
+    }
+
+    @When("User search for {string} in the MCP available tools & selects it")
+    public void user_search_for_app_in_mcp_and_select(String appName) {
+        playgroundPage.searchAndSelectMCPModel(appName);
+    }
+
      @Then("User verify the model catalog dropdown is present with default model with {string} name")
     public void user_Verify_The_Model_Catalog_Dropdown_Is_Present_With_Default_Model_With(String modelName) {
         playgroundPage.verifyModelCatalogDropdownPresent(modelName);

--- a/src/test/resources/Features/playground/PlaygroundConfiguration.feature
+++ b/src/test/resources/Features/playground/PlaygroundConfiguration.feature
@@ -1,27 +1,13 @@
 Feature: Playground Home model to verify configuration tab
 
-  @LoginWithAdmin @Regression
-  Scenario Outline: Validate Playground Configuration tab for Model - add model
+  Background: Playground Configuration tab for Model - add model
     Given User is on Home page
     When User opens Main Menu
     And User clicks on Open Model
     And User clicks on Add Model
-    And User selects '<MODEL_TYPE>' type
-    And User selects '<MODEL_NAME>'
-    And User enters Catalog Name as '<CATLOG_NAME>'
-    And User enters Open AI Key as '<KEY>'
-    And User clicks on Create Model button
-    And User can see a toast message as '<TOAST_MESSAGE>'
-    And User clicks on Edit button
-    And User add tags '<TAGS>' and presses Enter
-    And User clicks on Submit button
+    And User add "2" models with details "OpenAI" "GPT 3.5 Turbo" "Model" "Test@1234" "text-generation"
     And User clicks on Copy Catalog ID
-    Then User can see the Model title as '<CATLOG_NAME>'
-    Examples: 
-      | MODEL_TYPE | MODEL_NAME    | CATLOG_NAME | KEY       | TOAST_MESSAGE                     | TAGS            |
-      | OpenAI     | GPT 3.5 Turbo | Model1      | Test@1234 | Successfully added LLM to catalog | text-generation |
-      | OpenAI     | GPT 3.5 Turbo | Model2      | Test@1234 | Successfully added LLM to catalog | text-generation |
-
+    
   @LoginWithAdmin @Regression @DeleteTestCatalog
   Scenario: Validate Playground Configuration tab for Model - add/search Model
     Given User is on Home page

--- a/src/test/resources/Features/playground/PlaygroundConfigurationMCP.feature
+++ b/src/test/resources/Features/playground/PlaygroundConfigurationMCP.feature
@@ -1,0 +1,28 @@
+Feature: Playground Home model MCP to verify configuration tab
+
+  Background: Playground Configuration tab for Model - add model
+    Given User is on Home page
+    When User opens Main Menu
+    And User clicks on Open Model
+    And User clicks on Add Model
+    And User add "2" models with details "OpenAI" "GPT 3.5 Turbo" "Model" "Test@1234" "text-generation"
+    And User clicks on Copy Catalog ID
+
+  @LoginWithAdmin @Regression @DeleteTestCatalog @DeleteCreatedTestApp
+  Scenario: Validate Playground Configuration tab for Model - add/search Model
+    Given User is on Home page
+    When User clicks on Build button
+    And User clicks on Try it out hyperlink for Experiment in our Playground
+    And User clicks on the "Open Configuration Menu" button
+    And User clicks on the MCP dropdown
+    Then User should see and select the 'PlaygroundMCP app' in the MCP availale tools
+    And User verify added 'PlaygroundMCP app' is updated in selected list
+    When User saves the added MCP list
+    Then User verify the added 'PlaygroundMCP app' is displayed in MCP section
+    When User deletes the added 'PlaygroundMCP app' from MCP section
+    Then User verify the 'PlaygroundMCP app' is removed from MCP section
+    When User clicks on the MCP dropdown
+    And User search for 'PlaygroundMCP app' in the MCP available tools & selects it
+    Then User verify added 'PlaygroundMCP app' is updated in selected list
+    When User saves the added MCP list
+    Then User verify the added 'PlaygroundMCP app' is displayed in MCP section


### PR DESCRIPTION
## Scenario: Validate Playground Configuration Tab for Model - Add/Search Model
**Tags:**
**@LoginWithAdmin @Regression @DeleteTestCatalog @DeleteCreatedTestApp**
**Test steps include:**

- Navigating to the Home page
- Accessing the Build interface and launching an experiment via "Try it out"
- Interacting with the Configuration Menu and the MCP dropdown
- Selecting, verifying, saving, and deleting the 'PlaygroundMCP app' from the MCP available tools and ensuring all updates are reflected in the UI
- Searching and adding the 'PlaygroundMCP app' again, verifying its persistence post-save and correct listing in the MCP section