### PR TITLE
feat(551): verify playground chat feature

### DIFF
--- a/src/main/java/aicore/pages/PlaygroundPage.java
+++ b/src/main/java/aicore/pages/PlaygroundPage.java
@@ -87,6 +87,43 @@ public class PlaygroundPage {
         PlaygroundPageUtils.selectModelFromDropdown(page, modelName);
     }
 
+    public void clickOnSidebarToggleButton() {
+            PlaygroundPageUtils.clickOnSidebarToggleButton(page);
+    }
+
+    public void verifyPromptPresentInSidebarHistory(String prompt) {
+        PlaygroundPageUtils.verifyPromptPresentInSidebarHistory(page, prompt);
+    }
+
+    public void hoverOverSidebarHistoryItem(String prompt) {
+        PlaygroundPageUtils.hoverOverSidebarHistoryItem(page, prompt);
+    }
+
+    public void clickDeleteIconForSidebarHistoryItem(String prompt) {
+        PlaygroundPageUtils.clickDeleteIconForSidebarHistoryItem(page, prompt);
+    }
+
+    public void verifyPromptNotPresentInSidebarHistory(String prompt) {
+        PlaygroundPageUtils.verifyPromptNotPresentInSidebarHistory(page, prompt);
+    }
+
+    public void verifySidebarState(String state) {
+         if(state.equals("closed")) {
+            PlaygroundPageUtils.verifySidebarState(page,false);
+        }else if(state.equals("opened")) {
+            PlaygroundPageUtils.verifySidebarState(page,true);
+        }
+       
+    }
+
+    public void waitForModelResponse() {
+        PlaygroundPageUtils.waitForModelResponse(page);
+    }
+
+    public void verifyModelResponseDisplayed() {
+        PlaygroundPageUtils.verifyModelResponseDisplayed(page);
+    }
+
     public void verifyConfigurationMenuIsOpened() {
         PlaygroundPageUtils.verifyConfigurationMenuIsOpened(page);
     }

--- a/src/test/java/aicore/steps/AddModelSteps.java
+++ b/src/test/java/aicore/steps/AddModelSteps.java
@@ -208,7 +208,7 @@ public class AddModelSteps {
 		openModelPage.enterDescription(descriptionText);
 	}
 
-	@And("User add tags {string} and presses Enter")
+	@And("User add Tags {string} and presses Enter")
 	public void user_add_tags_and_presses_enter(String tags) {
 		String[] tagsArray = tags.split(", ");
 		for (String tag : tagsArray) {

--- a/src/test/java/aicore/steps/PlaygroundSteps.java
+++ b/src/test/java/aicore/steps/PlaygroundSteps.java
@@ -45,6 +45,16 @@ public class PlaygroundSteps {
         playgroundPage.clickOnOpenConfigurationMenuButton(buttonName);
     }
 
+    @And("User waits for the response from the model")
+    public void user_Waits_For_The_Response_From_The_Model() {
+        playgroundPage.waitForModelResponse();
+    }
+
+    @Then("User verifies that the response from the model is displayed as Prompt")
+    public void user_Verifies_That_The_Response_From_The_Model_Is_Displayed_As_Prompt() {
+        playgroundPage.verifyModelResponseDisplayed();
+    }
+
     @When("User clicks on the MCP dropdown")
     public void user_Clicks_On_The_MCP_Dropdown() {
         playgroundPage.clickOnMCPDropdown();
@@ -122,6 +132,36 @@ public class PlaygroundSteps {
         } else {
             playgroundPage.verifyButtonIsDisabled(buttonName);
         }
+    }
+
+    @When("User clicks on sidbar toggle button")
+    public void user_Clicks_On_Sidebar_Toggle_Button() {
+        playgroundPage.clickOnSidebarToggleButton();
+    }
+
+    @Then("User verifies that {string} prompt is present in the sidebar history")
+    public void user_Verifies_That_Prompt_Is_Present_In_The_Sidebar_History(String prompt) {
+        playgroundPage.verifyPromptPresentInSidebarHistory(prompt);
+    }
+
+    @When("User hovers over the sidebar history item with prompt {string}")
+    public void user_Hovers_Over_The_Sidebar_History_Item_With_Prompt(String prompt) {
+        playgroundPage.hoverOverSidebarHistoryItem(prompt);
+    }
+
+    @And("User clicks on the delete icon for the sidebar history item with prompt {string}")
+    public void user_Clicks_On_The_Delete_Icon_For_The_Sidebar_History_Item_With_Prompt(String prompt) {
+        playgroundPage.clickDeleteIconForSidebarHistoryItem(prompt);
+    }
+
+    @Then("User verifies that {string} prompt is no longer present in the sidebar history")
+    public void user_Verifies_That_Prompt_Is_No_Longer_Present_In_The_Sidebar_History(String prompt) {
+        playgroundPage.verifyPromptNotPresentInSidebarHistory(prompt);
+    }
+
+    @Then("User verifies that the sidebar is {string}")
+    public void user_Verifies_That_The_Sidebar_Is(String state) {
+        playgroundPage.verifySidebarState(state);
     }
 
     @Then("User sees the Configuration Menu is opened")

--- a/src/test/resources/Features/database/AddZipDatabase.feature
+++ b/src/test/resources/Features/database/AddZipDatabase.feature
@@ -29,7 +29,7 @@ Feature: Add Zip Database
   Scenario: View Database Tags
     Given User can see the Catalog title as 'TestDatabase'
     And User clicks on Edit button
-    And User add tags 'embeddings' and presses Enter
+    And User add Tags 'embeddings' and presses Enter
     And User clicks on Submit button
     Then User can see a edit success toast message as 'Successfully set the new metadata values for the engine'
     And User should see 'embeddings' on the page

--- a/src/test/resources/Features/database/ViewExistingDatabasesOnCatalogPage.feature
+++ b/src/test/resources/Features/database/ViewExistingDatabasesOnCatalogPage.feature
@@ -12,7 +12,7 @@ Feature: View existing databases on database catalog page
     And User sees success toast message 'Successfully Created Database'
     And User can see the Catalog title as 'TestDatabase'
     And User clicks on Edit button
-    And User add tags 'embeddings, Test1' and presses Enter
+    And User add Tags 'embeddings, Test1' and presses Enter
     And User enters the Domains as 'SAP, AI'
     And User selects 'IP, PHI' from the Data Classification dropdown
     And User selects 'IP ALLOWED, PHI ALLOWED' from the Data Restrictions dropdown

--- a/src/test/resources/Features/function/ViewExistingFunctionsOnCatalogPage.feature
+++ b/src/test/resources/Features/function/ViewExistingFunctionsOnCatalogPage.feature
@@ -11,7 +11,7 @@ Feature: View existing functions on Function Catalog Page
     And User clicks on Copy Catalog ID
     And User can see the Catalog title as 'WeatherFunctionTest'
     And User clicks on Edit button
-    And User add tags 'embeddings, Test1' and presses Enter
+    And User add Tags 'embeddings, Test1' and presses Enter
     And User enters the Domains as 'SAP, AI'
     And User selects 'IP, PHI' from the Data Classification dropdown
     And User selects 'IP ALLOWED, PHI ALLOWED' from the Data Restrictions dropdown

--- a/src/test/resources/Features/home/VerifySearchFunctionality.feature
+++ b/src/test/resources/Features/home/VerifySearchFunctionality.feature
@@ -71,7 +71,7 @@ Feature: Search app and catalogs
     And User clicks on Create Model button
     And User clicks on Copy Catalog ID
     When User clicks on Edit button
-    And User add tags 'embeddings' and presses Enter
+    And User add Tags 'embeddings' and presses Enter
     And User clicks on Submit button
     When User opens Main Menu
     And User clicks on Open Vector

--- a/src/test/resources/Features/model/AddModel.feature
+++ b/src/test/resources/Features/model/AddModel.feature
@@ -38,7 +38,7 @@ Feature: Add Model
   Scenario: Adding tag to Model to catalog - GPT 3.5 Turbo - embeddings
     Given User can see the Model title as 'Model'
     When User clicks on Edit button
-    And User add tags 'embeddings' and presses Enter
+    And User add Tags 'embeddings' and presses Enter
     And User clicks on Submit button
     Then User can see a edit success toast message as 'Successfully set the new metadata values for the engine'
     And User should see 'embeddings' on the page
@@ -59,7 +59,7 @@ Feature: Add Model
     And User clicks on Edit button
     And User enters the details as '<DETAILS>'
     And User enters the description as '<DESCRIPTION>'
-    And User add tags '<TAGS>' and presses Enter
+    And User add Tags '<TAGS>' and presses Enter
     And User enters the Domains as '<DOMAINS>'
     And User selects '<DATA_CLASSIFICATION>' from the Data Classification dropdown
     And User selects '<DATA_RESTRICTIONS>' from the Data Restrictions dropdown

--- a/src/test/resources/Features/model/ViewExistingModelOnCatalogPage.feature
+++ b/src/test/resources/Features/model/ViewExistingModelOnCatalogPage.feature
@@ -12,7 +12,7 @@ Feature: View existing models in model Catalog
     And User clicks on Copy Catalog ID
     Then User can see the Model title as 'Model'
     And User clicks on Edit button
-    And User add tags 'embeddings, Test1' and presses Enter
+    And User add Tags 'embeddings, Test1' and presses Enter
     And User enters the Domains as 'SAP, AI'
     And User selects 'IP, PHI' from the Data Classification dropdown
     And User selects 'IP ALLOWED, PHI ALLOWED' from the Data Restrictions dropdown

--- a/src/test/resources/Features/playground/PlaygroundChat.feature
+++ b/src/test/resources/Features/playground/PlaygroundChat.feature
@@ -1,0 +1,32 @@
+Feature: Playground Home Chat
+
+  Background: Validate Playground Home page chat - check prompt response
+    Given User is on Home page
+    When User opens Main Menu
+    And User clicks on Open Model
+    And User clicks on Add Model
+    And User clicks on file upload icon
+    And User uploads the file 'Model/Llama3-70B-Instruct.zip'
+    And User clicks on 'Upload' button to create catalog
+    When User clicks on Edit button
+    And User add Tags 'text-generation' and presses Enter
+    And User clicks on Submit button
+    And User clicks on Copy Catalog ID
+    And User is on Home page
+    And User clicks on Build button
+    And User clicks on Try it out hyperlink for Experiment in our Playground
+
+  @LoginWithAdmin @Regression @DeleteTestCatalog @DeleteCreatedTestApp.
+  Scenario: Validate Playground chat validatinos - add/remove histroy prompt
+    Given User sees the Prompt textarea with placeholder 'What do you want to do today?'
+    And User verifies that the 'Prompt the Model' button is 'disabled'
+    When User enters prompt in the Prompt textarea 'tell me a joke'
+    Then User verifies that the 'Prompt the Model' button is 'enabled'
+    When User clicks on the "Prompt the Model" button
+    And User waits for the response from the model
+    Then User verifies that the response from the model is displayed as Prompt
+    When User clicks on sidbar toggle button
+    Then User verifies that "tell me a joke" prompt is present in the sidebar history
+    When User hovers over the sidebar history item with prompt "tell me a joke"
+    And User clicks on the delete icon for the sidebar history item with prompt "tell me a joke"
+    Then User verifies that "tell me a joke" prompt is no longer present in the sidebar history

--- a/src/test/resources/Features/settings/TeamPermissions/TeamPermissionAddEngine.feature
+++ b/src/test/resources/Features/settings/TeamPermissions/TeamPermissionAddEngine.feature
@@ -120,7 +120,7 @@ Feature: Add Engine for Team Permission
     And User clicks on Create Model button
     And User clicks on Copy Catalog ID
     When User clicks on Edit button
-    And User add tags 'embeddings' and presses Enter
+    And User add Tags 'embeddings' and presses Enter
     And User clicks on Submit button
     Given User is on Home page
     When User opens Main Menu

--- a/src/test/resources/Features/settings/VectorSetting.feature
+++ b/src/test/resources/Features/settings/VectorSetting.feature
@@ -12,7 +12,7 @@ Feature: Search Vector Settings
     And User clicks on Copy Catalog ID
     Then User can see a toast message as 'Successfully added LLM to catalog'
     When User clicks on Edit button
-    And User add tags 'embeddings' and presses Enter
+    And User add Tags 'embeddings' and presses Enter
     And User clicks on Submit button
 
   @LoginWithAdmin @DeleteTestCatalog @Regression @Smoke

--- a/src/test/resources/Features/storage/AddStorage.feature
+++ b/src/test/resources/Features/storage/AddStorage.feature
@@ -43,7 +43,7 @@ Feature: Add Storage
     When User can see toast message as 'Successfully copied ID'
     #And User can see 'Please use the Edit button to provide a description for this Storage. A description will help others find the Storage and understand how to use it. To include more details associated with the Storage, edit the markdown located in the Overview section.' as storage description
     When User clicks on Edit button
-    And User add tags 'embeddings' and presses Enter
+    And User add Tags 'embeddings' and presses Enter
     And User clicks on Submit button
     Then User can see a edit success toast message as 'Successfully set the new metadata values for the engine'
     And User should see 'embeddings' on the page

--- a/src/test/resources/Features/storage/ViewExistingStorageOnCatalogPage.feature
+++ b/src/test/resources/Features/storage/ViewExistingStorageOnCatalogPage.feature
@@ -13,7 +13,7 @@ Feature: View existing Storages on storage Catalog Page
     And User clicks on Create Storage button
     And User clicks on Copy Catalog ID
     And User clicks on Edit button
-    And User add tags 'embeddings, Test1' and presses Enter
+    And User add Tags 'embeddings, Test1' and presses Enter
     And User enters the Domains as 'SAP, AI'
     And User selects 'PUBLIC, RESTRICTED' from the Data Classification dropdown
     And User selects 'FOUO ALLOWED, INTERNAL ALLOWED' from the Data Restrictions dropdown

--- a/src/test/resources/Features/vector/AddVectorDatabase.feature
+++ b/src/test/resources/Features/vector/AddVectorDatabase.feature
@@ -15,7 +15,7 @@ Feature: Add Vector Database
     #Then User can see a toast message as 'Successfully added LLM to catalog'
     And User clicks on Copy Catalog ID
     When User clicks on Edit button
-    And User add tags 'embeddings' and presses Enter
+    And User add Tags 'embeddings' and presses Enter
     And User clicks on Submit button
 
   @DeleteTestCatalog @Regression

--- a/src/test/resources/Features/vector/VectorOverview.feature
+++ b/src/test/resources/Features/vector/VectorOverview.feature
@@ -13,7 +13,7 @@ Feature: Vector Overview
     #And User can see a toast message as 'Successfully added LLM to catalog'
     And User clicks on Copy Catalog ID
     And User clicks on Edit button
-    And User add tags 'embeddings' and presses Enter
+    And User add Tags 'embeddings' and presses Enter
     And User clicks on Submit button
     And User opens Main Menu
     And User clicks on Open Vector
@@ -32,7 +32,7 @@ Feature: Vector Overview
   Scenario: Validate vector overview page
     Given User can see the Vector title as 'FAISS Vector DB00'
     When User clicks on Edit button
-    And User add tags 'TestTag' and presses Enter
+    And User add Tags 'TestTag' and presses Enter
     And User clicks on Submit button
     And 'Admin' user clicks on Settings
     And User clicks on Add Member button

--- a/src/test/resources/Features/vector/ViewExistingVectorOnCatalogPage.feature
+++ b/src/test/resources/Features/vector/ViewExistingVectorOnCatalogPage.feature
@@ -11,7 +11,7 @@ Feature: View existing Vectors on Vector Catalog Page
     And User clicks on Create Model button
     And User clicks on Copy Catalog ID
     And User clicks on Edit button
-    And User add tags 'embeddings' and presses Enter
+    And User add Tags 'embeddings' and presses Enter
     And User clicks on Submit button
     When User opens Main Menu
     And User clicks on Open Vector
@@ -25,7 +25,7 @@ Feature: View existing Vectors on Vector Catalog Page
     And User clicks on Create Vector button
     And User clicks on Copy Catalog ID
     And User clicks on Edit button
-    And User add tags 'embeddings, Test1' and presses Enter
+    And User add Tags 'embeddings, Test1' and presses Enter
     And User enters the Domains as 'SAP, AI'
     And User selects 'IP, PHI' from the Data Classification dropdown
     And User selects 'IP ALLOWED, PHI ALLOWED' from the Data Restrictions dropdown


### PR DESCRIPTION
## Feature File: Playground Home Chat
### Background Steps Automated:

- User navigates to the home page
- Opens Main Menu, selects and uploads an "LLM" model zip
- Creates a catalog, edits tags, copies catalog ID
- Navigates to "Try it out" section in the Playground

**Scenario Automated:**

- Checks presence and default state of the prompt textarea and associated button
- Verifies that button is only enabled with prompt text
- Submits a prompt ("tell me a joke") and waits for the LLM model's response
- Opens sidebar and validates presence of prompt in history
- Tests deleting prompt from history and ensures it no longer appears