### PR TITLE
feat: Validate engine access status

### DIFF
--- a/src/main/java/aicore/pages/AddModelPage.java
+++ b/src/main/java/aicore/pages/AddModelPage.java
@@ -369,6 +369,10 @@ public class AddModelPage {
 		SettingsModelPageUtils.clickOnDiscoverableModelsButton(page);
 	}
 
+	public void clickOnMakeCatalogPublicButton(String catalogName) {
+		SettingsModelPageUtils.clickOnMakeCatalogPublicButton(page, catalogName);
+	}
+
 	public void userClickOnCreatedModel() {
 		ModelPageUtils.userClickOnCreatedModel(page);
 
@@ -461,5 +465,13 @@ public class AddModelPage {
 
 	public void clickOnUploadButton(String buttonName) {
 		UploadModelUtils.clickOnUploadButton(page, buttonName);
+	}
+
+	public void mouseHoverOnEngineAccessStatusIcon() {
+		EditModelPageUtils.mouseHoverOnEngineAccessStatusIcon(page);
+	}
+
+	public String getEngineAccessStatusTooltipText(String status) {
+		return EditModelPageUtils.getEngineAccessStatusTooltipText(page, status);
 	}
 }

--- a/src/main/java/aicore/pages/home/MainMenuUtils.java
+++ b/src/main/java/aicore/pages/home/MainMenuUtils.java
@@ -48,7 +48,7 @@ public class MainMenuUtils {
 	public static void closeMainMenu(Page page) {
 		Locator menuOpen = page.locator(SEMOSS_OPEN_MEN_XPATH);
 		if (menuOpen.isVisible()) {
-			menuOpen.dblclick();
+			menuOpen.click();
 		}
 	}
 
@@ -105,7 +105,7 @@ public class MainMenuUtils {
 		locator.click();
 		MainMenuUtils.closeMainMenu(page);
 	}
-	
+
 	public static void clickOnUserAccountButton(Page page) {
 		page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Login")).click();
 	}

--- a/src/main/java/aicore/pages/model/EditModelPageUtils.java
+++ b/src/main/java/aicore/pages/model/EditModelPageUtils.java
@@ -33,6 +33,8 @@ public class EditModelPageUtils {
 	private static final String DOMAIN_TEXTBOX_DATATESTID = "editEngineDetails-Domain-autocomplete";
 	private static final String DATA_RESTRICTION_SELECT_XPATH = "//button[@id='data restrictions']";
 	private static final String DATA_CLASSIFICATION_SELECT_XAPTH = "//button[@id='data classification']";
+	private static final String ENGINE_ACCESS_STATUS_ICON_XPATH = "//*[contains(@class,'lucide lucide-lock-keyhole')]";
+	private static final String ENGINE_ACCESS_STATUS_TOOLTIP_XPATH = "//div[normalize-space(text())='{status}']";
 
 	public static void searchModelCatalog(Page page, String modelName) {
 		page.getByTestId("search-bar").click();
@@ -164,5 +166,16 @@ public class EditModelPageUtils {
 				.allInnerTexts();
 		CommonUtils.extractOverviewSectionValues(dataRestrictionOptions, dataRestrictionOptionsText);
 		return dataRestrictionOptions;
+	}
+
+	public static void mouseHoverOnEngineAccessStatusIcon(Page page) {
+		page.locator(ENGINE_ACCESS_STATUS_ICON_XPATH).nth(1).hover();
+	}
+
+	public static String getEngineAccessStatusTooltipText(Page page, String status) {
+//		String tooltipText = page.locator(ENGINE_ACCESS_STATUS_TOOLTIP_XPATH.replace("{status}", status)).textContent()
+//				.trim();
+//		return tooltipText;
+		return page.getByText(status).first().innerText();
 	}
 }

--- a/src/main/java/aicore/pages/model/SettingsModelPageUtils.java
+++ b/src/main/java/aicore/pages/model/SettingsModelPageUtils.java
@@ -43,6 +43,7 @@ public class SettingsModelPageUtils {
 	private static final String DELETE_CATALOG_BUTTON_XPATH = "//button[contains(@data-testid,'-delete-btn')]";
 	private static final String CONFIRMATION_POPUP_DELETE_BUTTON_XPATH = "//button[contains(@data-testid,'confirmDelete-btn')]";
 	private static final String DISCOVERABLE_MODELS_BUTTON_DATA_TESTID = "engineIndexPage-Models-discoverable-switch";
+	private static final String PRIVATE_MODELS_BUTTON_DATA_TESTID = "settingsTiles-make-{catalogName}-public-private-switch";
 
 	public static void clickOnSettingsTab(Page page) {
 		page.click(SETTINGS_TAB_XPATH);
@@ -233,5 +234,9 @@ public class SettingsModelPageUtils {
 
 	public static void clickOnDiscoverableModelsButton(Page page) {
 		page.getByTestId(DISCOVERABLE_MODELS_BUTTON_DATA_TESTID).click();
+	}
+
+	public static void clickOnMakeCatalogPublicButton(Page page, String catalogName) {
+		page.getByTestId(PRIVATE_MODELS_BUTTON_DATA_TESTID.replace("{catalogName}", catalogName)).click();
 	}
 }

--- a/src/test/java/aicore/steps/AddModelSteps.java
+++ b/src/test/java/aicore/steps/AddModelSteps.java
@@ -126,7 +126,7 @@ public class AddModelSteps {
 		for (Map<String, String> row : rows) {
 			String fieldName = row.get("fieldName");
 			String fieldValue = row.get("fieldValue");
-				openModelPage.fillModelCreationForm(fieldName, fieldValue);
+			openModelPage.fillModelCreationForm(fieldName, fieldValue);
 		}
 	}
 
@@ -631,4 +631,19 @@ public class AddModelSteps {
 		openModelPage.clickOnUploadButton(buttonName);
 	}
 
+	@When("User mouse hover on Lock icon displayed on catalog card")
+	public void user_mouse_hover_on_lock_icon_displayed_on_catalog_card() {
+		openModelPage.mouseHoverOnEngineAccessStatusIcon();
+	}
+
+	@Then("User can see engine access status as {string} on the tooltip")
+	public void user_can_see_engine_access_status_as_on_the_tooltip(String expectedStatus) {
+		String actualStatus = openModelPage.getEngineAccessStatusTooltipText(expectedStatus);
+		Assertions.assertEquals(expectedStatus, actualStatus, "Incorrect status");
+	}
+
+	@When("User clicks on make {string} public button")
+	public void user_clicks_on_make_public_button(String catalogName) {
+		openModelPage.clickOnMakeCatalogPublicButton(catalogName);
+	}
 }

--- a/src/test/java/aicore/steps/AddStorageSteps.java
+++ b/src/test/java/aicore/steps/AddStorageSteps.java
@@ -37,7 +37,7 @@ public class AddStorageSteps extends AbstractAddCatalogBase {
 
 	@Given("User clicks on Open Storage")
 	public void user_clicks_on_open_storage() {
-		MainMenuUtils.clickOnOpenSettings(SetupHooks.getPage());
+		MainMenuUtils.clickOnOpenStorage(SetupHooks.getPage());
 	}
 
 	@When("User clicks on Add Storage button")

--- a/src/test/resources/Features/database/ViewExistingDatabasesOnCatalogPage.feature
+++ b/src/test/resources/Features/database/ViewExistingDatabasesOnCatalogPage.feature
@@ -36,7 +36,7 @@ Feature: View existing databases on database catalog page
     When User clicks on bookmark button to unbookmark 'TestDatabase' catalog
 
   @LoginWithAdmin @Regression @DeleteTestCatalog
-  Scenario: Validate access status of created function catalog
+  Scenario: Validate access status of created Database catalog
     Given User opens Main Menu
     When User clicks on Open Database
     And User searches the 'TestDatabase' in the database Catalog searchbox

--- a/src/test/resources/Features/database/ViewExistingDatabasesOnCatalogPage.feature
+++ b/src/test/resources/Features/database/ViewExistingDatabasesOnCatalogPage.feature
@@ -34,3 +34,21 @@ Feature: View existing databases on database catalog page
     When User clicks on bookmark button of 'TestDatabase' catalog
     Then User sees the catalog name 'TestDatabase' in the Bookmarked section
     When User clicks on bookmark button to unbookmark 'TestDatabase' catalog
+
+  @LoginWithAdmin @Regression @DeleteTestCatalog
+  Scenario: Validate access status of created function catalog
+    Given User opens Main Menu
+    When User clicks on Open Database
+    And User searches the 'TestDatabase' in the database Catalog searchbox
+    And User sees the database name 'TestDatabase' in the database catalog
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Private' on the tooltip
+    When User clicks on the database name 'TestDatabase' in the database catalog
+    And User clicks on Access Control Tab
+    And User clicks on make 'Database' public button
+    And User opens Main Menu
+    And User clicks on Open Database
+    And User searches the 'TestDatabase' in the database Catalog searchbox
+    And User sees the database name 'TestDatabase' in the database catalog
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Global' on the tooltip

--- a/src/test/resources/Features/function/ViewExistingFunctionsOnCatalogPage.feature
+++ b/src/test/resources/Features/function/ViewExistingFunctionsOnCatalogPage.feature
@@ -16,7 +16,7 @@ Feature: View existing functions on Function Catalog Page
     And User selects 'IP, PHI' from the Data Classification dropdown
     And User selects 'IP ALLOWED, PHI ALLOWED' from the Data Restrictions dropdown
     And User clicks on Submit button
-    #Then User can see a edit success toast message as 'Successfully set the new metadata values for the engine'
+    Then User can see a edit success toast message as 'Successfully set the new metadata values for the engine'
 
   @LoginWithAdmin @Regression @DeleteTestCatalog
   Scenario: view and validate filter functionality - My Functions
@@ -30,7 +30,7 @@ Feature: View existing functions on Function Catalog Page
       | Data Classification | IP                |
       | Data Restrictions   | IP ALLOWED        |
 
-  @DeleteTestCatalog @Regression 
+  @DeleteTestCatalog @Regression
   Scenario: view and validate filter functionality - Discoverable Functions
     Given User opens Main Menu
     When User clicks on Open Function
@@ -50,3 +50,21 @@ Feature: View existing functions on Function Catalog Page
       | Data Restrictions   | IP ALLOWED   |
     When User logs out from the application
     And User login as 'admin'
+
+  @LoginWithAdmin @Regression @DeleteTestCatalog
+  Scenario: Validate access status of created function catalog
+    When User opens Main Menu
+    And User clicks on Open Function
+    And User searches the 'WeatherFunctionTest' in the function Catalog searchbox
+    Then User sees the function name 'WeatherFunctionTest' in the function catalog
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Private' on the tooltip
+    When User selects the 'WeatherFunctionTest' from the function catalog
+    And User clicks on Access Control Tab
+    And User clicks on make 'Function' public button
+    And User opens Main Menu
+    And User clicks on Open Function
+    And User searches the 'WeatherFunctionTest' in the function Catalog searchbox
+    Then User sees the function name 'WeatherFunctionTest' in the function catalog
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Global' on the tooltip

--- a/src/test/resources/Features/function/ViewExistingFunctionsOnCatalogPage.feature
+++ b/src/test/resources/Features/function/ViewExistingFunctionsOnCatalogPage.feature
@@ -52,7 +52,7 @@ Feature: View existing functions on Function Catalog Page
     And User login as 'admin'
 
   @LoginWithAdmin @Regression @DeleteTestCatalog
-  Scenario: Validate access status of created function catalog
+  Scenario: Validate access status of created Function catalog
     When User opens Main Menu
     And User clicks on Open Function
     And User searches the 'WeatherFunctionTest' in the function Catalog searchbox

--- a/src/test/resources/Features/guardrail/ValidateGuardrailCatalog.feature
+++ b/src/test/resources/Features/guardrail/ValidateGuardrailCatalog.feature
@@ -43,22 +43,3 @@ Feature: Validate Guardrail catalog
     Then User sees export success toast message as 'Guardrail engine download started'
     And User sees catalog zip file downloaded
     And User sees downloaded zip file name contains 'Gliner guardrail'
-
-  Scenario: view and validate filter functionality - Guardrails
-    When User clicks on Edit button
-    And User enters the details as 'Gliner guardrail'
-    And User enters the description as 'Test Gliner guardrail catalog'
-    And User add Tags 'embeddings, Test1, Test2, Test3' and presses Enter
-    And User enters the Domains as 'SAP, AI, Finance'
-    And User selects 'IP, PHI, PII, PUBLIC' from the Data Classification dropdown
-    And User selects 'IP ALLOWED, PHI ALLOWED, FOUO ALLOWED' from the Data Restrictions dropdown
-    And User clicks on Submit button
-    Then User can see a edit success toast message as 'Successfully set the new metadata values for the engine'
-    And User opens Main Menu
-    And User clicks on Guardrail
-    And User applies each filter and validate 'Gliner guardrail' catalog is visible on the 'Guardrail' catalog page
-      | FILTER_CATEGORY     | FILTER_VALUE                          |
-      | Tag                 | embeddings, Test1                     |
-      | Domain              | SAP, AI                               |
-      | Data Classification | IP, PHI, PII, PUBLIC                  |
-      | Data Restrictions   | IP ALLOWED, PHI ALLOWED, FOUO ALLOWED |

--- a/src/test/resources/Features/guardrail/ViewExistingGuardrailOnCatalogPage.feature
+++ b/src/test/resources/Features/guardrail/ViewExistingGuardrailOnCatalogPage.feature
@@ -1,0 +1,50 @@
+Feature: View existing Guardrail on Guardrail Catalog Page
+
+  Background: Create Guardrail catalog
+    Given User opens Main Menu
+    When User clicks on Guardrail
+    And User clicks on Add Guardrail button
+    And User selects 'Gliner'
+    And User enters guardrail Catalog Name as 'Gliner guardrail'
+    And User enters NER Labels as 'label' and presses Enter
+    And User enters Default Threshold as '1'
+    And User clicks on 'Connect' button
+    And User clicks on Copy Catalog ID
+    Then User can see a toast message as 'Successfully added new guardrail to catalog'
+    And User can see the Guardrail Catalog title as 'Gliner guardrail'
+
+  @LoginWithAdmin @DeleteTestCatalog @Regression
+  Scenario: view and validate filter functionality - Guardrails
+    When User clicks on Edit button
+    And User enters the details as 'Gliner guardrail'
+    And User enters the description as 'Test Gliner guardrail catalog'
+    And User add Tags 'embeddings, Test1, Test2, Test3' and presses Enter
+    And User enters the Domains as 'SAP, AI, Finance'
+    And User selects 'IP, PHI, PII, PUBLIC' from the Data Classification dropdown
+    And User selects 'IP ALLOWED, PHI ALLOWED, FOUO ALLOWED' from the Data Restrictions dropdown
+    And User clicks on Submit button
+    Then User can see a edit success toast message as 'Successfully set the new metadata values for the engine'
+    And User opens Main Menu
+    And User clicks on Guardrail
+    And User applies each filter and validate 'Gliner guardrail' catalog is visible on the 'Guardrail' catalog page
+      | FILTER_CATEGORY     | FILTER_VALUE                          |
+      | Tag                 | embeddings, Test1                     |
+      | Domain              | SAP, AI                               |
+      | Data Classification | IP, PHI, PII, PUBLIC                  |
+      | Data Restrictions   | IP ALLOWED, PHI ALLOWED, FOUO ALLOWED |
+
+  @LoginWithAdmin @Regression @DeleteTestCatalog
+  Scenario: Validate access status of created Guardrail catalog
+    Given User opens Main Menu
+    When User clicks on Guardrail
+    And User searches the 'Gliner guardrail' in the guardrail Catalog searchbox
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Private' on the tooltip
+    When User selects the 'Gliner guardrail' from the guardrail catalog
+    And User clicks on Access Control Tab
+    And User clicks on make 'Guardrail' public button
+    And User opens Main Menu
+    And User clicks on Guardrail
+    And User searches the 'Gliner guardrail' in the guardrail Catalog searchbox
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Global' on the tooltip

--- a/src/test/resources/Features/model/ViewExistingModelOnCatalogPage.feature
+++ b/src/test/resources/Features/model/ViewExistingModelOnCatalogPage.feature
@@ -12,28 +12,28 @@ Feature: View existing models in model Catalog
     And User clicks on Copy Catalog ID
     Then User can see the Model title as 'Model'
 
-  #@LoginWithAdmin @Regression @DeleteTestCatalog
-  #Scenario: view and validate filter functionality - My Functions
-    #When User clicks on Edit button
-    #And User add Tags 'embeddings, Test1' and presses Enter
-    #And User enters the Domains as 'SAP, AI'
-    #And User selects 'IP, PHI' from the Data Classification dropdown
-    #And User selects 'IP ALLOWED, PHI ALLOWED' from the Data Restrictions dropdown
-    #And User clicks on Submit button
-    #Then User can see a edit success toast message as 'Successfully set the new metadata values for the engine'
-    #When User opens Main Menu
-    #And User clicks on Open Model
-    #And User searches the 'Model' in the model catalog searchbox
-    #Then User should see the 'Model' on the model catalog page
-    #And User applies each filter and validate 'Model' catalog is visible on the 'model' catalog page
-      #| FILTER_CATEGORY     | FILTER_VALUE      |
-      #| Tag                 | embeddings, Test1 |
-      #| Domain              | SAP, AI           |
-      #| Data Classification | IP                |
-      #| Data Restrictions   | IP ALLOWED        |
-    #When User clicks on bookmark button of 'Model' catalog
-    #Then User sees the catalog name 'Model' in the Bookmarked section
-    #When User clicks on bookmark button to unbookmark 'Model' catalog
+  @LoginWithAdmin @Regression @DeleteTestCatalog
+  Scenario: view and validate filter functionality - My Functions
+    When User clicks on Edit button
+    And User add Tags 'embeddings, Test1' and presses Enter
+    And User enters the Domains as 'SAP, AI'
+    And User selects 'IP, PHI' from the Data Classification dropdown
+    And User selects 'IP ALLOWED, PHI ALLOWED' from the Data Restrictions dropdown
+    And User clicks on Submit button
+    Then User can see a edit success toast message as 'Successfully set the new metadata values for the engine'
+    When User opens Main Menu
+    And User clicks on Open Model
+    And User searches the 'Model' in the model catalog searchbox
+    Then User should see the 'Model' on the model catalog page
+    And User applies each filter and validate 'Model' catalog is visible on the 'model' catalog page
+      | FILTER_CATEGORY     | FILTER_VALUE      |
+      | Tag                 | embeddings, Test1 |
+      | Domain              | SAP, AI           |
+      | Data Classification | IP                |
+      | Data Restrictions   | IP ALLOWED        |
+    When User clicks on bookmark button of 'Model' catalog
+    Then User sees the catalog name 'Model' in the Bookmarked section
+    When User clicks on bookmark button to unbookmark 'Model' catalog
 
   @LoginWithAdmin @Regression @DeleteTestCatalog
   Scenario: Validate access status of created model

--- a/src/test/resources/Features/model/ViewExistingModelOnCatalogPage.feature
+++ b/src/test/resources/Features/model/ViewExistingModelOnCatalogPage.feature
@@ -36,7 +36,7 @@ Feature: View existing models in model Catalog
     When User clicks on bookmark button to unbookmark 'Model' catalog
 
   @LoginWithAdmin @Regression @DeleteTestCatalog
-  Scenario: Validate access status of created model
+  Scenario: Validate access status of created Model catalog
     When User opens Main Menu
     And User clicks on Open Model
     And User searches the 'Model' in the model catalog searchbox

--- a/src/test/resources/Features/model/ViewExistingModelOnCatalogPage.feature
+++ b/src/test/resources/Features/model/ViewExistingModelOnCatalogPage.feature
@@ -1,6 +1,6 @@
 Feature: View existing models in model Catalog
 
-  Background: Create a Model - GPT 4.1 
+  Background: Create a Model - GPT 4.1
     Given User opens Main Menu
     When User clicks on Open Model
     And User clicks on Add Model
@@ -11,26 +11,44 @@ Feature: View existing models in model Catalog
     And User clicks on Create Model button
     And User clicks on Copy Catalog ID
     Then User can see the Model title as 'Model'
-    And User clicks on Edit button
-    And User add Tags 'embeddings, Test1' and presses Enter
-    And User enters the Domains as 'SAP, AI'
-    And User selects 'IP, PHI' from the Data Classification dropdown
-    And User selects 'IP ALLOWED, PHI ALLOWED' from the Data Restrictions dropdown
-    And User clicks on Submit button
-    # Then User can see a edit success toast message as 'Successfully set the new metadata values for the engine'
 
-  @LoginWithAdmin @Regression @DeleteTestCatalog
-  Scenario: view and validate filter functionality - My Functions
-    Given User opens Main Menu
-    When User clicks on Open Model
-    And User searches the 'Model' in the model catalog searchbox
-    Then User should see the 'Model' on the model catalog page
-    And User applies each filter and validate 'Model' catalog is visible on the 'model' catalog page
-      | FILTER_CATEGORY     | FILTER_VALUE      |
-      | Tag                 | embeddings, Test1 |
-      | Domain              | SAP, AI           |
-      | Data Classification | IP                |
-      | Data Restrictions   | IP ALLOWED        |
+  #@LoginWithAdmin @Regression @DeleteTestCatalog
+  #Scenario: view and validate filter functionality - My Functions
+    #When User clicks on Edit button
+    #And User add Tags 'embeddings, Test1' and presses Enter
+    #And User enters the Domains as 'SAP, AI'
+    #And User selects 'IP, PHI' from the Data Classification dropdown
+    #And User selects 'IP ALLOWED, PHI ALLOWED' from the Data Restrictions dropdown
+    #And User clicks on Submit button
+    #Then User can see a edit success toast message as 'Successfully set the new metadata values for the engine'
+    #When User opens Main Menu
+    #And User clicks on Open Model
+    #And User searches the 'Model' in the model catalog searchbox
+    #Then User should see the 'Model' on the model catalog page
+    #And User applies each filter and validate 'Model' catalog is visible on the 'model' catalog page
+      #| FILTER_CATEGORY     | FILTER_VALUE      |
+      #| Tag                 | embeddings, Test1 |
+      #| Domain              | SAP, AI           |
+      #| Data Classification | IP                |
+      #| Data Restrictions   | IP ALLOWED        |
     #When User clicks on bookmark button of 'Model' catalog
     #Then User sees the catalog name 'Model' in the Bookmarked section
     #When User clicks on bookmark button to unbookmark 'Model' catalog
+
+  @LoginWithAdmin @Regression @DeleteTestCatalog
+  Scenario: Validate access status of created model
+    When User opens Main Menu
+    And User clicks on Open Model
+    And User searches the 'Model' in the model catalog searchbox
+    Then User should see the 'Model' on the model catalog page
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Private' on the tooltip
+    When User selects the 'Model' from the model catalog
+    And User clicks on Access Control Tab
+    And User clicks on make 'Model' public button
+    And User opens Main Menu
+    And User clicks on Open Model
+    And User searches the 'Model' in the model catalog searchbox
+    Then User should see the 'Model' on the model catalog page
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Global' on the tooltip

--- a/src/test/resources/Features/storage/ViewExistingStorageOnCatalogPage.feature
+++ b/src/test/resources/Features/storage/ViewExistingStorageOnCatalogPage.feature
@@ -56,7 +56,7 @@ Feature: View existing Storages on storage Catalog Page
     And User login as 'Admin'
 
   @LoginWithAdmin @Regression @DeleteTestCatalog
-  Scenario: Validate access status of created storage catalog
+  Scenario: Validate access status of created Storage catalog
     Given User opens Main Menu
     When User clicks on Open Storage
     And User searches the 'Amazon S3 Storage' in the storage Catalog searchbox

--- a/src/test/resources/Features/storage/ViewExistingStorageOnCatalogPage.feature
+++ b/src/test/resources/Features/storage/ViewExistingStorageOnCatalogPage.feature
@@ -5,7 +5,7 @@ Feature: View existing Storages on storage Catalog Page
     When User clicks on Open Storage
     And User clicks on Add Storage button
     And User selects 'Amazon S3' storage
-    And User enters storage Catalog name as 'Amazon-S3-Storage'
+    And User enters storage Catalog name as 'Amazon S3 Storage'
     And User enters Region as 'India'
     And User enters Bucket as 'BucketTest'
     And User enters Access Key as 'Test123'
@@ -18,39 +18,55 @@ Feature: View existing Storages on storage Catalog Page
     And User selects 'PUBLIC, RESTRICTED' from the Data Classification dropdown
     And User selects 'FOUO ALLOWED, INTERNAL ALLOWED' from the Data Restrictions dropdown
     And User clicks on Submit button
-    
-  @LoginWithAdmin @DeleteTestCatalog @Regression 
+
+  @LoginWithAdmin @DeleteTestCatalog @Regression
   Scenario: view and validate filter functionality - My Storages
     Given User opens Main Menu
     When User clicks on Open Storage
-    And User searches the 'Amazon-S3-Storage' in the storage Catalog searchbox
-    Then User applies each filter and validate 'Amazon-S3-Storage' catalog is visible on the 'storage' catalog page
+    And User searches the 'Amazon S3 Storage' in the storage Catalog searchbox
+    Then User applies each filter and validate 'Amazon S3 Storage' catalog is visible on the 'storage' catalog page
       | FILTER_CATEGORY     | FILTER_VALUE      |
       | Tag                 | embeddings, Test1 |
       | Domain              | SAP, AI           |
       | Data Classification | PUBLIC            |
       | Data Restrictions   | FOUO ALLOWED      |
-    When User clicks on bookmark button of 'Amazon-S3-Storage' catalog
-    Then User sees the catalog name 'Amazon-S3-Storage' in the Bookmarked section
-    When User clicks on bookmark button to unbookmark 'Amazon-S3-Storage' catalog
+    When User clicks on bookmark button of 'Amazon S3 Storage' catalog
+    Then User sees the catalog name 'Amazon S3 Storage' in the Bookmarked section
+    When User clicks on bookmark button to unbookmark 'Amazon S3 Storage' catalog
 
-  @DeleteTestCatalog @Regression 
+  @DeleteTestCatalog @Regression
   Scenario: view and validate filter functionality - Discoverable Storages
     Given User opens Main Menu
     When User clicks on Open Storage
-    And User searches the 'Amazon-S3-Storage' in the storage Catalog searchbox
-    And User selects the 'Amazon-S3-Storage' from the storage catalog
+    And User searches the 'Amazon S3 Storage' in the storage Catalog searchbox
+    And User selects the 'Amazon S3 Storage' from the storage catalog
     And User clicks on Access Control Tab
     And User clicks Make 'Storage' Discoverable button
     And User logs out from the application
     And User login as 'editor'
     And User opens Main Menu
     And User clicks on Open Storage
-    And User searches the 'Amazon-S3-Storage' in the storage Catalog searchbox
+    And User searches the 'Amazon S3 Storage' in the storage Catalog searchbox
     And User clicks on Discoverable Storages button
-    Then User applies each filter and validate 'Amazon-S3-Storage' catalog is visible on the 'storage' catalog page
+    Then User applies each filter and validate 'Amazon S3 Storage' catalog is visible on the 'storage' catalog page
       | FILTER_CATEGORY     | FILTER_VALUE     |
       | Data Classification | RESTRICTED       |
       | Data Restrictions   | INTERNAL ALLOWED |
     And User logs out from the application
     And User login as 'Admin'
+
+  @LoginWithAdmin @Regression @DeleteTestCatalog
+  Scenario: Validate access status of created storage catalog
+    Given User opens Main Menu
+    When User clicks on Open Storage
+    And User searches the 'Amazon S3 Storage' in the storage Catalog searchbox
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Private' on the tooltip
+    When User selects the 'Amazon S3 Storage' from the storage catalog
+    And User clicks on Access Control Tab
+    And User clicks on make 'Storage' public button
+    And User opens Main Menu
+    And User clicks on Open Storage
+    And User searches the 'Amazon S3 Storage' in the storage Catalog searchbox
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Global' on the tooltip

--- a/src/test/resources/Features/vector/ViewExistingVectorOnCatalogPage.feature
+++ b/src/test/resources/Features/vector/ViewExistingVectorOnCatalogPage.feature
@@ -17,7 +17,7 @@ Feature: View existing Vectors on Vector Catalog Page
     And User clicks on Open Vector
     And User clicks on Add Vector button
     And User selects 'FAISS' connection
-    And User enters vector database Catalog name as 'FAISSVector'
+    And User enters vector database Catalog name as 'FAISS Vector'
     And User selects 'ModelCatalog' from Embedder field
     And User selects 'Token' from Chunking Strategy field
     And User enters value of Content Length as '510'
@@ -35,34 +35,50 @@ Feature: View existing Vectors on Vector Catalog Page
   Scenario: view and validate filter functionality - My Vectors
     Given User opens Main Menu
     When User clicks on Open Vector
-    And User searches the 'FAISSVector' in the Vector Catalog searchbox
-    Then User applies each filter and validate 'FAISSVector' catalog is visible on the 'vector' catalog page
+    And User searches the 'FAISS Vector' in the Vector Catalog searchbox
+    Then User applies each filter and validate 'FAISS Vector' catalog is visible on the 'vector' catalog page
       | FILTER_CATEGORY     | FILTER_VALUE      |
       | Tag                 | embeddings, Test1 |
       | Domain              | SAP, AI           |
       | Data Classification | IP                |
       | Data Restrictions   | IP ALLOWED        |
-    #When User clicks on bookmark button of 'FAISSVector' catalog
-    #Then User sees the catalog name 'FAISSVector' in the Bookmarked section
-    #When User clicks on bookmark button to unbookmark 'FAISSVector' catalog
+    When User clicks on bookmark button of 'FAISS Vector' catalog
+    Then User sees the catalog name 'FAISS Vector' in the Bookmarked section
+    When User clicks on bookmark button to unbookmark 'FAISS Vector' catalog
 
-  @DeleteTestCatalog @Regression  @LoginWithAdmin
+  @DeleteTestCatalog @Regression @LoginWithAdmin
   Scenario: view and validate filter functionality - Discoverable Vectors
     Given User opens Main Menu
     When User clicks on Open Vector
-    And User searches the 'FAISSVector' in the Vector Catalog searchbox
-    And User selects the 'FAISSVector' from the Vector catalog
+    And User searches the 'FAISS Vector' in the Vector Catalog searchbox
+    And User selects the 'FAISS Vector' from the Vector catalog
     And User clicks on Access Control Tab
     And User clicks Make 'Vector' Discoverable button
     And User logs out from the application
     And User login as 'editor'
     And User opens Main Menu
     And User clicks on Open Vector
-    And User searches the 'FAISSVector' in the Vector Catalog searchbox
+    And User searches the 'FAISS Vector' in the Vector Catalog searchbox
     And User clicks on Discoverable Vectors button
-    And User applies each filter and validate 'FAISSVector' catalog is visible on the 'vector' catalog page
+    And User applies each filter and validate 'FAISS Vector' catalog is visible on the 'vector' catalog page
       | FILTER_CATEGORY     | FILTER_VALUE |
       | Data Classification | IP           |
       | Data Restrictions   | IP ALLOWED   |
     And User logs out from the application
     And User login as 'Admin'
+
+  @LoginWithAdmin @Regression @DeleteTestCatalog
+  Scenario: Validate access status of created vector catalog
+    Given User opens Main Menu
+    When User clicks on Open Vector
+    And User searches the 'FAISS Vector' in the Vector Catalog searchbox
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Private' on the tooltip
+    When User selects the 'FAISS Vector' from the Vector catalog
+    And User clicks on Access Control Tab
+    And User clicks on make 'Vector' public button
+    And User opens Main Menu
+    And User clicks on Open Vector
+    And User searches the 'FAISS Vector' in the Vector Catalog searchbox
+    When User mouse hover on Lock icon displayed on catalog card
+    Then User can see engine access status as 'Global' on the tooltip

--- a/src/test/resources/Features/vector/ViewExistingVectorOnCatalogPage.feature
+++ b/src/test/resources/Features/vector/ViewExistingVectorOnCatalogPage.feature
@@ -68,7 +68,7 @@ Feature: View existing Vectors on Vector Catalog Page
     And User login as 'Admin'
 
   @LoginWithAdmin @Regression @DeleteTestCatalog
-  Scenario: Validate access status of created vector catalog
+  Scenario: Validate access status of created Vector catalog
     Given User opens Main Menu
     When User clicks on Open Vector
     And User searches the 'FAISS Vector' in the Vector Catalog searchbox


### PR DESCRIPTION
## Description
This PR includes validation of engine access status (private/Global) which is displayed on created catalog card.

## How to Test
1. Open the application
2. Create Model catalog
3. Navigate to catalog list page
4. Mouse hover on Lock icon displayed on created catalog card
5. Validate the status displayed on tooltip (Private)
6. Open the Access Control tab
7. Make catalog as Public
8. Again, navigate to catalog list page
9. Mouse hover on Lock icon displayed on created catalog card
10. Validate the status displayed on tooltip (Global)
11. Repeat steps for all other catalogs