### PR TITLE
Feature/at 944 model catalog validate mcp generation

### DIFF
--- a/src/main/java/aicore/pages/AddModelPage.java
+++ b/src/main/java/aicore/pages/AddModelPage.java
@@ -511,4 +511,16 @@ public class AddModelPage {
 	public boolean isButtonVisibleOnDeleteConfirmation(String buttonName) {
 		return EditModelPageUtils.isButtonVisibleOnDeleteConfirmation(page, buttonName);
 	}
+
+	public void clickOnGenerateMCPButtonFromMCPUsageTab() {
+		EditModelPageUtils.clickOnGenerateMCPButtonFromMCPUsageTab(page);
+	}
+
+	public boolean verifyToolsInGeneratedMCP(String toolName) {
+		return EditModelPageUtils.verifyToolsInGeneratedMCP(page, toolName);
+	}
+
+	public boolean verifyInputParameters(List<String> expectedParameters) {
+		return EditModelPageUtils.verifyInputParameters(page, expectedParameters);
+	}
 }

--- a/src/main/java/aicore/pages/model/EditModelPageUtils.java
+++ b/src/main/java/aicore/pages/model/EditModelPageUtils.java
@@ -45,6 +45,10 @@ public class EditModelPageUtils {
 	private static final String DELETE_CONFIRMATION_MESSAGE_XPATH = "//div[@role='dialog']//p[text()='Are you sure you want to delete this engine?']";
 	private static final String DELETE_CONFIRMATION_POPUP_ENAGINE_NAME_XAPTH = "//span[text()='Engine Name:']/following-sibling::span";
 	private static final String DELETE_CONFIRMATION_POPUP_ENAGINE_ID_XAPTH = "//span[text()='Engine ID:']/following-sibling::span";
+	private static final String VIEW_INPUT_PARAMETERS_XPATH = "//code[text()='{parameters}']";
+	private static final String VIEW_INPUT_PARAMETER_XPATH = "//summary[contains(text(),'View input parameters')]";
+	private static final String GENRATE_MCP_CONFIRAMTION_BUTTON_XPATH = "//button[text()='Yes']";
+	private static final String VIEW_AVAILABLE_TOOL_XPATH = "//div//h4[text()='Available Tools']/following::div//h4[text()='{toolName}']";
 
 	public static void searchModelCatalog(Page page, String modelName) {
 		page.getByTestId("search-bar").click();
@@ -271,5 +275,37 @@ public class EditModelPageUtils {
 	public static boolean isButtonVisibleOnDeleteConfirmation(Page page, String buttonName) {
 		Locator buttonLocator = page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName(buttonName));
 		return buttonLocator.isVisible();
+	}
+
+	public static void clickOnGenerateMCPButtonFromMCPUsageTab(Page page) {
+		Locator generateMCPButton = page.getByRole(AriaRole.BUTTON,
+				new Page.GetByRoleOptions().setName("Generate MCP"));
+		generateMCPButton.click();
+		page.locator(GENRATE_MCP_CONFIRAMTION_BUTTON_XPATH).click();
+	}
+
+	public static boolean verifyToolsInGeneratedMCP(Page page, String toolName) {
+		Locator toolLocator = page.locator(VIEW_AVAILABLE_TOOL_XPATH.replace("{toolName}", toolName));
+		AICorePageUtils.waitFor(toolLocator);
+		if (!toolLocator.isVisible()) {
+			return false;
+		}
+		return true;
+	}
+
+	public static boolean verifyInputParameters(Page page, String[] viewInputParameters) {
+		Locator viewInputParameterLocator = page.locator(VIEW_INPUT_PARAMETER_XPATH);
+		viewInputParameterLocator.isVisible();
+		viewInputParameterLocator.click();
+		for (String inputParameter : viewInputParameters) {
+			Locator parameterLocator = page
+					.locator(VIEW_INPUT_PARAMETERS_XPATH.replace("{parameters}", inputParameter));
+			parameterLocator.waitFor();
+			parameterLocator.scrollIntoViewIfNeeded();
+			if (!parameterLocator.isVisible()) {
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/src/main/java/aicore/pages/model/EditModelPageUtils.java
+++ b/src/main/java/aicore/pages/model/EditModelPageUtils.java
@@ -293,15 +293,12 @@ public class EditModelPageUtils {
 		return true;
 	}
 
-	public static boolean verifyInputParameters(Page page, String[] viewInputParameters) {
+	public static boolean verifyInputParameters(Page page, List<String> viewInputParameters) {
 		Locator viewInputParameterLocator = page.locator(VIEW_INPUT_PARAMETER_XPATH);
 		viewInputParameterLocator.isVisible();
 		viewInputParameterLocator.click();
 		for (String inputParameter : viewInputParameters) {
-			Locator parameterLocator = page
-					.locator(VIEW_INPUT_PARAMETERS_XPATH.replace("{parameters}", inputParameter));
-			parameterLocator.waitFor();
-			parameterLocator.scrollIntoViewIfNeeded();
+			Locator parameterLocator = page.locator(VIEW_INPUT_PARAMETERS_XPATH.replace("{parameters}", inputParameter));
 			if (!parameterLocator.isVisible()) {
 				return false;
 			}

--- a/src/test/java/aicore/steps/AddModelSteps.java
+++ b/src/test/java/aicore/steps/AddModelSteps.java
@@ -744,4 +744,24 @@ public class AddModelSteps {
 		}
 	}
 
+	@And("User clicks on Generate MCP button")
+	public void user_clicks_on_generate_mcp_button() {
+		openModelPage.clickOnGenerateMCPButtonFromMCPUsageTab();
+	}
+
+	@And("User can see the Avialble Tools as {string}")
+	public void user_can_see_the_available_tools_as(String expectedTool) {
+		boolean isToolPresent = openModelPage.verifyToolsInGeneratedMCP(expectedTool);
+		Assertions.assertTrue(isToolPresent, "Tool are not displayed as expected in generated MCP");
+	}
+
+	@And("User can see the below Input parameters under the View parameter")
+	public void user_can_see_the_below_input_parameters_under_the_view_parameter(DataTable dataTable) {
+		String param = dataTable.cell(0, 0);
+		List<String> expectedParameters = Arrays.asList(param.split(", "));
+		boolean isInputParameterPresent = openModelPage.verifyInputParameters(expectedParameters);
+		Assertions.assertTrue(isInputParameterPresent,
+				"Input parameters are not displayed as expected in generated MCP ");
+	}
+
 }

--- a/src/test/java/aicore/unit/model/ModelSpecificPageTests.java
+++ b/src/test/java/aicore/unit/model/ModelSpecificPageTests.java
@@ -29,7 +29,6 @@ import aicore.pages.model.SettingsModelPageUtils;
 import aicore.utils.AICorePageUtils;
 import aicore.utils.AddCatalogPageBaseUtils;
 import aicore.utils.CommonUtils;
-import aicore.utils.FunctionTestUtils;
 import aicore.utils.page.model.ModelPageUtils;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -251,26 +250,4 @@ public class ModelSpecificPageTests {
 					"Model id count does not match for section '" + sectionName + "'");
 		}
 	}
-
-	@Test
-	@Order(7) // Run SEVENTH - read-only test, validates model catalog id in code snippets
-	@Tag("model")
-	@DisplayName("Validate the available tool and their input parameter after MCP Generation")
-	public void testValidateToolsAfterMCPGeneration() {
-		String toolName = "LLM";
-		String[] viewInputParameters = { "useHistory", "paramValues", "image", "engine", "context", "command", "roomId",
-				"url" };
-		String toasterMessage = "MCP generated";
-		ModelPageUtils.verifyModelTitle(page, modelCatalogName);
-		AICorePageUtils.clickOnTabButton(page, " MCP Usage");
-		EditModelPageUtils.clickOnGenerateMCPButtonFromMCPUsageTab(page);
-		FunctionTestUtils.verifyUserSeesSuccessToastMessage(page, toasterMessage);
-		boolean isToolPresent = EditModelPageUtils.verifyToolsInGeneratedMCP(page, toolName);
-		Assertions.assertTrue(isToolPresent, "Tool are not displayed as expected in generated MCP");
-		boolean isInputParameterPresent = EditModelPageUtils.verifyInputParameters(page, viewInputParameters);
-		Assertions.assertTrue(isInputParameterPresent,
-				"Input parameters are not displayed as expected in generated MCP "
-						+ Arrays.toString(viewInputParameters));
-	}
-
 }

--- a/src/test/java/aicore/unit/model/ModelSpecificPageTests.java
+++ b/src/test/java/aicore/unit/model/ModelSpecificPageTests.java
@@ -29,14 +29,14 @@ import aicore.pages.model.SettingsModelPageUtils;
 import aicore.utils.AICorePageUtils;
 import aicore.utils.AddCatalogPageBaseUtils;
 import aicore.utils.CommonUtils;
+import aicore.utils.FunctionTestUtils;
 import aicore.utils.page.model.ModelPageUtils;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ModelSpecificPageTests {
-	
+
 	private static String modelCatalogName = null;
 	private static Page page = null;
-
 
 	@BeforeAll
 	public static void setup() throws IOException {
@@ -63,7 +63,7 @@ public class ModelSpecificPageTests {
 		AddModelFormUtils.enterOpenAIKey(page, openAIKey);
 		AddModelFormUtils.clickOnCreateModelButton(page);
 	}
-	
+
 	@BeforeEach
 	public void navigateToModelPage() {
 		// Ensure we're on the model details page before each test
@@ -72,12 +72,12 @@ public class ModelSpecificPageTests {
 		MainMenuUtils.clickOnOpenModel(page);
 		EditModelPageUtils.searchModelCatalog(page, modelCatalogName);
 		EditModelPageUtils.selectModelFromSearchOptions(page, modelCatalogName);
-		
+
 		// Wait for page to stabilize
 		page.waitForLoadState();
 		page.waitForTimeout(500); // Small buffer for any animations
 	}
-	
+
 	@AfterAll
 	public static void teardown() {
 		// Clean up: delete the test model catalog
@@ -89,8 +89,8 @@ public class ModelSpecificPageTests {
 			}
 		}
 	}
-	
-	@Order(1)  // Run FIRST - read-only test
+
+	@Order(1) // Run FIRST - read-only test
 	@Test
 	@Tag("model")
 	@DisplayName("Verify SMSS properties are displayed correctly for a model")
@@ -105,9 +105,9 @@ public class ModelSpecificPageTests {
 		String actualVarName = CommonUtils.splitTrimValue(fullModelVarNameSmss, "VAR_NAME");
 		Assertions.assertEquals(actualVarName, "myModel", "Var name is not matching");
 	}
-	
+
 	@Test
-	@Order(5)  // Run FIFTH - modifies SMSS properties
+	@Order(5) // Run FIFTH - modifies SMSS properties
 	@Tag("model")
 	@DisplayName("Edit SMSS properties and verify changes are persisted")
 	public void testEditSMSS() {
@@ -121,12 +121,13 @@ public class ModelSpecificPageTests {
 		String fullModelVarNameSmss = ModelSMSSPageUtils.verifyVarNameInSMSS(page);
 		String actualVarName = CommonUtils.splitTrimValue(fullModelVarNameSmss, "VAR_NAME");
 		Assertions.assertEquals(actualVarName, "New_Name", "Var name is not matching");
-		String fullConversationHistory = ModelSMSSPageUtils.verifyKeepConversationHistoryValueInSMSS(page, "KEEP_CONVERSATION_HISTORY");
+		String fullConversationHistory = ModelSMSSPageUtils.verifyKeepConversationHistoryValueInSMSS(page,
+				"KEEP_CONVERSATION_HISTORY");
 		actualVarName = CommonUtils.splitTrimValue(fullConversationHistory, "KEEP_CONVERSATION_HISTORY");
 		Assertions.assertEquals(actualVarName, "True", "Conversation history setting is not matching");
 	}
-	
-	@Order(2)  // Run SECOND - read-only test
+
+	@Order(2) // Run SECOND - read-only test
 	@Test
 	@Tag("model")
 	@DisplayName("Add tag to model and verify it appears on the page")
@@ -136,11 +137,11 @@ public class ModelSpecificPageTests {
 		AddCatalogPageBaseUtils.enterTagName(page, "embeddings");
 		AddCatalogPageBaseUtils.clickOnSubmit(page);
 		List<String> actualTagList = EditModelPageUtils.verifyTagNames(page);
-		List<String> expectedTagList = Arrays.asList(new String[] {"embeddings"});
+		List<String> expectedTagList = Arrays.asList(new String[] { "embeddings" });
 		Assertions.assertEquals(expectedTagList, actualTagList);
 	}
 
-	@Order(3)  // Run THIRD - read-only test
+	@Order(3) // Run THIRD - read-only test
 	@Test
 	@Tag("model")
 	@DisplayName("View existing models in Model Catalog")
@@ -152,7 +153,7 @@ public class ModelSpecificPageTests {
 		Assertions.assertTrue(isModelDisplayed);
 	}
 
-	@Order(4)  // Run FOURTH - modifies model details and tags
+	@Order(4) // Run FOURTH - modifies model details and tags
 	@Test
 	@Tag("model")
 	@DisplayName("Edit model details")
@@ -162,25 +163,25 @@ public class ModelSpecificPageTests {
 		EditModelPageUtils.searchModelCatalog(page, modelCatalogName);
 		EditModelPageUtils.selectModelFromSearchOptions(page, modelCatalogName);
 		AddCatalogPageBaseUtils.clickEditIcon(page);
-		
+
 		String detailsText = "GPT-4.1 model";
 		EditModelPageUtils.enterDetails(page, detailsText);
-		
+
 		String descriptionText = "This is GPT-4.1 test model";
 		EditModelPageUtils.enterDescription(page, descriptionText);
-		
+
 		String tagNames = "embeddings, Test1";
 		String[] tagsArray = tagNames.split(", ");
 		for (String tag : tagsArray) {
 			AddCatalogPageBaseUtils.enterTagName(page, tag);
 		}
-		
+
 		String domainNames = "SAP, AI, Finance";
 		String[] allDomainNames = domainNames.split(", ");
 		for (String domainName : allDomainNames) {
 			EditModelPageUtils.enterDomainName(page, domainName);
 		}
-		
+
 		String dataClassificationOptions = "IP, PHI, PII, PUBLIC";
 		String[] classificationOptions = dataClassificationOptions.split(", ");
 		for (String option : classificationOptions) {
@@ -212,16 +213,18 @@ public class ModelSpecificPageTests {
 		Assertions.assertEquals(actualDomainList, expectedDomainList);
 		// verify data classification
 		List<String> expectedDataClassificationOptionsList = Arrays.asList(classificationOptions);
-		List<String> actualDataClassificationOptionsList = EditModelPageUtils.verifyDataClassificationOptionsUnderOverview(page);
+		List<String> actualDataClassificationOptionsList = EditModelPageUtils
+				.verifyDataClassificationOptionsUnderOverview(page);
 		Assertions.assertEquals(actualDataClassificationOptionsList, expectedDataClassificationOptionsList);
 		// verfy data restrctions
 		List<String> expectedDataRestrictionOptionsList = Arrays.asList(restrictionsOptions);
-		List<String> actualDataRestrictionOptionsList = EditModelPageUtils.verifyDataRestrictionOptionsUnderOverview(page);
+		List<String> actualDataRestrictionOptionsList = EditModelPageUtils
+				.verifyDataRestrictionOptionsUnderOverview(page);
 		Assertions.assertEquals(actualDataRestrictionOptionsList, expectedDataRestrictionOptionsList);
 	}
 
 	@Test
-	@Order(6)  // Run SIXTH - read-only test, validates model ID
+	@Order(6) // Run SIXTH - read-only test, validates model ID
 	@Tag("model")
 	@DisplayName("Validate model catalog id occurences in usage sections")
 	public void testViewModelCatalogId() {
@@ -231,24 +234,43 @@ public class ModelSpecificPageTests {
 
 		// Create test data structure to replace DataTable
 		// Each entry: [section name, expected count]
-		Object[][] testData = {
-			{"How to use in Pixel", 5},
-			{"How to use in Python", 1},
-			{"How to use with LangChain API", 1},
-			{"How to use externally with OpenAI API (with or without our Python SDK)", 4},
-			{"How to use in Java", 1}
-		};
+		Object[][] testData = { { "How to use in Pixel", 5 }, { "How to use in Python", 1 },
+				{ "How to use with LangChain API", 1 },
+				{ "How to use externally with OpenAI API (with or without our Python SDK)", 4 },
+				{ "How to use in Java", 1 } };
 
 		// Validate model catalog id occurences in each section
 		for (Object[] data : testData) {
 			String sectionName = (String) data[0];
 			int expectedCount = (int) data[1];
-			
+
 			String copiedSectionContents = SettingsModelPageUtils.getFullSectionCodeByHeading(page, sectionName);
 			int countIdOccurances = CommonUtils.countIdOccurances(copiedSectionContents, modelId);
-			
+
 			Assertions.assertEquals(expectedCount, countIdOccurances,
 					"Model id count does not match for section '" + sectionName + "'");
 		}
 	}
+
+	@Test
+	@Order(7) // Run SEVENTH - read-only test, validates model catalog id in code snippets
+	@Tag("model")
+	@DisplayName("Validate the available tool and their input parameter after MCP Generation")
+	public void testValidateToolsAfterMCPGeneration() {
+		String toolName = "LLM";
+		String[] viewInputParameters = { "useHistory", "paramValues", "image", "engine", "context", "command", "roomId",
+				"url" };
+		String toasterMessage = "MCP generated";
+		ModelPageUtils.verifyModelTitle(page, modelCatalogName);
+		AICorePageUtils.clickOnTabButton(page, " MCP Usage");
+		EditModelPageUtils.clickOnGenerateMCPButtonFromMCPUsageTab(page);
+		FunctionTestUtils.verifyUserSeesSuccessToastMessage(page, toasterMessage);
+		boolean isToolPresent = EditModelPageUtils.verifyToolsInGeneratedMCP(page, toolName);
+		Assertions.assertTrue(isToolPresent, "Tool are not displayed as expected in generated MCP");
+		boolean isInputParameterPresent = EditModelPageUtils.verifyInputParameters(page, viewInputParameters);
+		Assertions.assertTrue(isInputParameterPresent,
+				"Input parameters are not displayed as expected in generated MCP "
+						+ Arrays.toString(viewInputParameters));
+	}
+
 }

--- a/src/test/resources/Features/model/AddModel.feature
+++ b/src/test/resources/Features/model/AddModel.feature
@@ -11,7 +11,7 @@ Feature: Add Model
     And User enters Catalog Name as 'Model'
     And User enters Open AI Key as 'Test@1234'
     And User clicks on Create Model button
-    ##And User can see a toast message as 'Successfully added LLM to catalog'
+    And User can see a toast message as 'Successfully added LLM to catalog'
     And User clicks on Copy Catalog ID
     Then User can see the Model title as 'Model'
 
@@ -68,9 +68,9 @@ Feature: Add Model
     And User should see '<DATA_CLASSIFICATION>' in the overview Data classification section
     And User should see '<DATA_RESTRICTIONS>' in the overview Data restrictions section
 
-    Examples: 
+    Examples:
       | MODEL_NAME | DETAILS       | DESCRIPTION                | TAGS              | DOMAINS          | DATA_CLASSIFICATION  | DATA_RESTRICTIONS                     |
-      | Model      | GPT-4.1 model | This is GPT-4.1 test model | embeddings, Test1 | SAP, AI, Finance | IP, PHI, PII, PUBLIC | IP ALLOWED, PHI ALLOWED, FOUO ALLOWED |
+      | Model      | GPT-4.1 model | This is GPT-4.1 test model | embeddings, Test1 | SAP, AI, Finance | IP, PHI, PII, Public | IP Allowed, PHI Allowed, FOUO Allowed |
 
   Scenario: Validate Model Catalog ID in Usage commands
     Given User can see the Model title as 'Model'
@@ -78,8 +78,17 @@ Feature: Add Model
     And User clicks on Usage tab
     When User copies code contents and validate model catalog Id occurences in sections:
       | SECTIONS                                                               | EXPECTED_MODEL_ID_COUNT |
-      | How to use in Pixel                                                    |                       5 |
-      | How to use in Python                                                   |                       1 |
-      | How to use with LangChain API                                          |                       1 |
-      | How to use externally with OpenAI API (with or without our Python SDK) |                       3 |
-      | How to use in Java                                                     |                       1 |
+      | How to use in Pixel                                                    | 5                       |
+      | How to use in Python                                                   | 1                       |
+      | How to use with LangChain API                                          | 1                       |
+      | How to use externally with OpenAI API (with or without our Python SDK) | 4                       |
+      | How to use in Java                                                     | 1                       |
+
+  Scenario: Validate the available tool and their input parameter after MCP Generation
+    Given User can see the Model title as 'Model'
+    When User clicks on 'MCP Usage' tab
+    And User clicks on Generate MCP button
+    Then User can see a toast message as 'MCP generated'
+    And User can see the Avialble Tools as 'LLM'
+    And User can see the below Input parameters under the View parameter
+      | useHistory, paramValues, image, engine, context, command, roomId, url |


### PR DESCRIPTION
## Description
Implement the script for Model Catalog , when user click on Generate MCP button from MCP Usage tab then available tools we can see the the Tool and their input parameter 

Step to Test:

1. Login the Application
2. Navigate to the Model catalog
3. Create any catalog as GPT-5
4. Click on MCP Usage Tab
5. Click on Generate MCP
6. Check the Tools are displyed

Note: Fixed the two scenario as per latest UI 
1.Validate Model Catalog ID in Usage command
2.Edit Model Deatils



