### PR TITLE
feat(#1005): Validate the Notification when Admin User Accept the Request 

### DIFF
--- a/src/main/java/aicore/pages/model/EditModelPageUtils.java
+++ b/src/main/java/aicore/pages/model/EditModelPageUtils.java
@@ -45,6 +45,7 @@ public class EditModelPageUtils {
 	private static final String VIEW_INPUT_PARAMETER_XPATH = "//h4[text()='{toolName}']/ancestor::div/following::summary[contains(text(),'View input parameters')]";
 	private static final String GENRATE_MCP_CONFIRAMTION_BUTTON_XPATH = "//button[text()='Yes']";
 	private static final String VIEW_AVAILABLE_TOOL_XPATH = "//div//h4[text()='Available Tools']/following::div//h4[text()='{toolName}']";
+	private static final String REQUEST_ACCESS_BUTTON = "//button[text()='Request Access']";
 
 	public static void searchModelCatalog(Page page, String modelName) {
 		page.getByTestId("search-bar").click();
@@ -276,4 +277,9 @@ public class EditModelPageUtils {
 		}
 		return true;
 	}
+
+	public static void clickOnRequestAccessButtonOfDiscoverableCatalog(Page page) {
+		page.locator(REQUEST_ACCESS_BUTTON).click();
+	}
+
 }

--- a/src/main/java/aicore/pages/notifications/NotificationsUtils.java
+++ b/src/main/java/aicore/pages/notifications/NotificationsUtils.java
@@ -4,10 +4,11 @@ import com.microsoft.playwright.Page;
 
 public class NotificationsUtils {
 	public static final String NOTIFICATION_BELL_ICON_XPATH_ = "//button[@aria-label='Notifications']";
-	public static final String USER_ADDED_NOTIFICATION_MESSAGE_FOR_USER_XPATH = "//div[@data-testid='notification-item'][.//span[normalize-space()='{accessProvided}'] and .//span[normalize-space()='{catalogName}'] and .//span[normalize-space()='{accessProvidedByUser}User']] //div[span[contains(text(),'You are added as')]]";
+	public static final String USER_ADDED_NOTIFICATION_MESSAGE_FOR_USER_XPATH = "//div[@data-testid='notification-item'][.//span[normalize-space()='{accessProvided}'] and .//span[normalize-space()='{catalogName}'] and .//span[normalize-space()='{accessProvidedByUser}']] //div[span[contains(text(),'You are added as')]]";
 	public static final String NOTIFICATION_PANE_CLOSE_XPATH = "//h2[text()='Notifications']/parent::div/following-sibling::button[span[text()='Close']]";
-	public static final String USER_ADDED_NOTIFICATION_MESSAGE_FOR_OWNER_XPATH = "//div[@data-testid='notification-item'][.//span[normalize-space()='{userName} User'] and .//span[normalize-space()='{accessProvided}'] and .//span[normalize-space()='{catalogName}']] //div[span[contains(text(),'has been added as')]]";
-	public static final String USER_ADDED_NOTIFICATION_MESSAGE_FOR_OTHER_OWNER_XPATH = "//div[@data-testid='notification-item'][.//span[normalize-space()=\"{userName} User's\"] and .//span[normalize-space()='{accessProvided}'] and .//span[normalize-space()='{catalogName}'] and .//span[normalize-space()='{accessProvidedByUser}User']]//div[span[contains(text(),'has been added as')]]";
+	public static final String USER_ADDED_NOTIFICATION_MESSAGE_FOR_OWNER_XPATH = "//div[@data-testid='notification-item'][.//span[normalize-space()='{accessProvided}'] and .//span[normalize-space()='{catalogName}']] //div[span[contains(text(),'has been added as')]]";
+	public static final String USER_ADDED_NOTIFICATION_MESSAGE_FOR_OTHER_OWNER_XPATH = "//div[@data-testid='notification-item'][.//span[normalize-space()='{accessProvided}'] and .//span[normalize-space()='{catalogName}'] and .//span[normalize-space()='{accessProvidedByUser}']]//div[span[contains(text(),'has been added as')]]";
+	public static final String REQUEST_ACTION_NOTIFICATION_XPATH = "//div[@data-testid='notification-item']//div[@class='text-sm'][.//span[normalize-space()='Your request for'] and .//span[normalize-space()='{accessType}'] and .//span[normalize-space()='permission on'] and .//span[normalize-space()='{catalogName}'] and .//span[normalize-space()='has been approved by'] and .//span[contains(text(),'{userName}')]]";
 
 	public static void clickOnNotificationBellIcon(Page page) {
 		page.locator(NOTIFICATION_BELL_ICON_XPATH_).click();
@@ -23,25 +24,32 @@ public class NotificationsUtils {
 		return actualMessage;
 	}
 
-	public static String validateUserAddedNotificationMessageForOwner(Page page, String userName, String accessProvided,
+	public static String validateUserAddedNotificationMessageForOwner(Page page, String accessProvided,
 			String catalogName) {
-		String actualMessage = page
-				.locator(USER_ADDED_NOTIFICATION_MESSAGE_FOR_OWNER_XPATH.replace("{userName}", userName)
-						.replace("{accessProvided}", accessProvided).replace("{catalogName}", catalogName))
-				.first().textContent().trim();
+		String actualMessage = page.locator(USER_ADDED_NOTIFICATION_MESSAGE_FOR_OWNER_XPATH
+				.replace("{accessProvided}", accessProvided).replace("{catalogName}", catalogName)).first()
+				.textContent().trim();
 
 		return actualMessage;
 	}
 
-	public static String validateUserAddedNotificationMessageForOtherOwner(Page page, String userName, String role,
-			String catalogName, String addedBy) {
-		String actualMessage = page.locator(USER_ADDED_NOTIFICATION_MESSAGE_FOR_OTHER_OWNER_XPATH
-				.replace("{userName}", userName).replace("{accessProvided}", role).replace("{catalogName}", catalogName)
-				.replace("{accessProvidedByUser}", addedBy)).first().textContent().trim();
+	public static String validateUserAddedNotificationMessageForOtherOwner(Page page, String role, String catalogName,
+			String addedBy) {
+		String actualMessage = page
+				.locator(USER_ADDED_NOTIFICATION_MESSAGE_FOR_OTHER_OWNER_XPATH.replace("{accessProvided}", role)
+						.replace("{catalogName}", catalogName).replace("{accessProvidedByUser}", addedBy))
+				.first().textContent().trim();
 		return actualMessage;
 	}
 
 	public static void closeNotificationPane(Page page) {
 		page.locator(NOTIFICATION_PANE_CLOSE_XPATH).click();
+	}
+
+	public static String validateActionPerformOnRequestAccessNotificationMessage(Page page, String accessType,
+			String catalogName, String byUser) {
+		String actualMessage = page.locator(REQUEST_ACTION_NOTIFICATION_XPATH.replace("{accessType}", accessType)
+				.replace("{catalogName}", catalogName).replace("{userName}", byUser)).textContent().trim();
+		return actualMessage;
 	}
 }

--- a/src/test/java/aicore/unit/app/DragAndDropApp/CreateAppUsingUploadZip.java
+++ b/src/test/java/aicore/unit/app/DragAndDropApp/CreateAppUsingUploadZip.java
@@ -5,25 +5,28 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.microsoft.playwright.Page;
+
 import aicore.pages.home.MainMenuUtils;
-import aicore.utils.AbstractE2ETest;
+import aicore.utils.AbstractPlaywrightTestBase;
 import aicore.utils.CatalogCreationFromZipUtil;
 import aicore.utils.CommonUtils;
 import aicore.utils.TestResources;
+import aicore.utils.annotations.PWPage;
 import aicore.utils.page.app.AppPageUtils;
 import aicore.utils.page.app.CreateAppPopupUtils;
 import aicore.utils.page.app.DragAndDropBlocksPageUtils;
 
-public class CreateAppUsingUploadZip extends AbstractE2ETest {
+public class CreateAppUsingUploadZip extends AbstractPlaywrightTestBase {
 
 	@BeforeAll
-	static void setup() {
-		login(page, UserType.NATIVE);
+	void setup(@PWPage Page page) {
+		loginNativeAdmin(page);
 	}
 
 	@Test
 	@DisplayName("Create App Using Upload Zip")
-	public void testExportDataFunctionality() {
+	public void testExportDataFunctionality(@PWPage Page page) {
 		String fileName = TestResources.APP_FILE;
 		MainMenuUtils.openMainMenu(page);
 		MainMenuUtils.clickOnOpenAppLibrary(page);

--- a/src/test/java/aicore/unit/notifications/model/NotificationsTests.java
+++ b/src/test/java/aicore/unit/notifications/model/NotificationsTests.java
@@ -1,4 +1,4 @@
-package aicore.unit.model;
+package aicore.unit.notifications.model;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -9,12 +9,17 @@ import org.junit.jupiter.api.Test;
 import com.microsoft.playwright.Page;
 
 import aicore.base.GenericSetupUtils;
+import aicore.framework.ConfigUtils;
+import aicore.pages.function.FunctionAccessSettingsUtils;
 import aicore.pages.home.MainMenuUtils;
 import aicore.pages.model.AddModelFormUtils;
+import aicore.pages.model.EditModelPageUtils;
 import aicore.pages.model.SettingsModelPageUtils;
 import aicore.pages.notifications.NotificationsUtils;
 import aicore.utils.AbstractPlaywrightTestBase;
+import aicore.utils.AddFunctionPageUtils;
 import aicore.utils.CommonUtils;
+import aicore.utils.RequestAccessPopupUtils;
 import aicore.utils.TestResourceTrackerHelper;
 import aicore.utils.annotations.PWPage;
 import aicore.utils.page.model.ModelPageUtils;
@@ -47,7 +52,7 @@ public class NotificationsTests extends AbstractPlaywrightTestBase {
 	@DisplayName("Validate newly added member received notification")
 	public void verifyNewlyAddedMemberReceivesNotification(@PWPage Page page) throws InterruptedException {
 		String accessProvided = "Editor";
-		String accessProvidedByUser = "Admin";
+		String byUser = ConfigUtils.getValue("Admin".toUpperCase() + "_USERNAME").split("@")[0];
 		// Open access control tab and add a new member
 		SettingsModelPageUtils.clickOnAccessControl(page);
 		SettingsModelPageUtils.clickOnAddMembersButton(page);
@@ -60,9 +65,8 @@ public class NotificationsTests extends AbstractPlaywrightTestBase {
 		MainMenuUtils.clickOnOpenModel(page);
 		NotificationsUtils.clickOnNotificationBellIcon(page);
 		String actualUserAddedNotificationMessage = NotificationsUtils.validateUserAddedNotificationMessageForUser(page,
-				accessProvided, catalogName, accessProvidedByUser);
-		String expectedMessage = String.format("You are added as %s to %s by %s.", accessProvided, catalogName,
-				accessProvidedByUser + "User");
+				accessProvided, catalogName, byUser);
+		String expectedMessage = String.format("You are added as %s to %s by %s.", accessProvided, catalogName, byUser);
 		Assertions.assertEquals(expectedMessage, actualUserAddedNotificationMessage,
 				"The notification message is not as expected.");
 		// Close the notification pane
@@ -84,11 +88,12 @@ public class NotificationsTests extends AbstractPlaywrightTestBase {
 		// Validate the notification message for the owner who added the new member
 		NotificationsUtils.clickOnNotificationBellIcon(page);
 		String actualUserAddedNotificationMessageForOwner = NotificationsUtils
-				.validateUserAddedNotificationMessageForOwner(page, "Author", "Author", catalogName);
-		String expectedUserAddedNotificationMessageForOwner = String.format("%s has been added as %s to %s by you.",
-				"Author User", "Author", catalogName);
-		Assertions.assertEquals(expectedUserAddedNotificationMessageForOwner,
-				actualUserAddedNotificationMessageForOwner, "The notification message is not as expected.");
+				.validateUserAddedNotificationMessageForOwner(page, "Author", catalogName);
+		String expectedUserAddedNotificationMessageForOwner = String.format("has been added as %s to %s by you.",
+				"Author", catalogName);
+		Assertions.assertTrue(
+				actualUserAddedNotificationMessageForOwner.contains(expectedUserAddedNotificationMessageForOwner),
+				"The notification message is not as expected.");
 		// Close the notification pane
 		NotificationsUtils.closeNotificationPane(page);
 		// Now add another member as Editor
@@ -101,17 +106,63 @@ public class NotificationsTests extends AbstractPlaywrightTestBase {
 		MainMenuUtils.openMainMenu(page);
 		MainMenuUtils.clickOnOpenModel(page);
 		NotificationsUtils.clickOnNotificationBellIcon(page);
+		String byUser = ConfigUtils.getValue("Admin".toUpperCase() + "_USERNAME").split("@")[0];
 		String actualUserAddedNotificationMessageForOtherOwner = NotificationsUtils
-				.validateUserAddedNotificationMessageForOtherOwner(page, "Editor", "Editor", catalogName, "Admin");
-		String expectedUserAddedNotificationMessageForOtherOwner = String
-				.format("%s User's has been added as %s to %s by %sUser.", "Editor", "Editor", catalogName, "Admin");
-		Assertions.assertEquals(expectedUserAddedNotificationMessageForOtherOwner,
-				actualUserAddedNotificationMessageForOtherOwner, "The notification message is not as expected.");
+				.validateUserAddedNotificationMessageForOtherOwner(page, "Editor", catalogName, byUser);
+		String expectedUserAddedNotificationMessageForOtherOwner = String.format("has been added as %s to %s by %s.",
+				"Editor", catalogName, byUser);
+		Assertions.assertTrue(
+				actualUserAddedNotificationMessageForOtherOwner
+						.contains(expectedUserAddedNotificationMessageForOtherOwner),
+				"The notification message is not as expected.");
 		// Close the notification pane
 		NotificationsUtils.closeNotificationPane(page);
 		// Logout from newly added member account and login back with Admin for cleanup
 		logout(page);
 		loginNativeAdmin(page);
+	}
+
+	@Test
+	@DisplayName("Validate Notification message for Accept the request")
+	public void testAcceptRequestAndValidateMemberList(@PWPage Page page) {
+		AddFunctionPageUtils.clickOnAccessControl(page);
+		FunctionAccessSettingsUtils.clickOnMakeDiscoverableButton(page, "Model");
+		logout(page);
+		loginEditor(page);
+		MainMenuUtils.openMainMenu(page);
+		MainMenuUtils.clickOnOpenModel(page);
+		SettingsModelPageUtils.clickOnDiscoverableModelsButton(page);
+		EditModelPageUtils.searchModelCatalog(page, catalogName);
+		EditModelPageUtils.selectModelFromSearchOptions(page, catalogName);
+		EditModelPageUtils.clickOnRequestAccessButtonOfDiscoverableCatalog(page);
+		RequestAccessPopupUtils.selectAccessType(page, "author");
+		RequestAccessPopupUtils.enterComment(page, "Access Request");
+		RequestAccessPopupUtils.clickOnRequestButton(page);
+		logout(page);
+		loginAdmin(page);
+		MainMenuUtils.openMainMenu(page);
+		MainMenuUtils.clickOnOpenModel(page);
+		EditModelPageUtils.searchModelCatalog(page, catalogName);
+		EditModelPageUtils.selectModelFromSearchOptions(page, catalogName);
+		AddFunctionPageUtils.clickOnAccessControl(page);
+		String actualCountWithText = SettingsModelPageUtils.getPendingRequestCountText(page);
+		Assertions.assertEquals("1 pending request", actualCountWithText, "Pending request text not correct");
+		SettingsModelPageUtils.clickOnPendingRequestsExpandButton(page);
+		SettingsModelPageUtils.performActionOnPendingRequest(page, "Approve");
+		String actualMessage = ModelPageUtils.modelCreationToastMessage(page, "Successfully approved user permissions");
+		Assertions.assertEquals(actualMessage, "Successfully approved user permissions",
+				"Approval toast message not correct");
+		logout(page);
+		loginEditor(page);
+		NotificationsUtils.clickOnNotificationBellIcon(page);
+		String byUser = ConfigUtils.getValue("Admin".toUpperCase() + "_USERNAME").split("@")[0];
+		String actualNotificationMessage = NotificationsUtils
+				.validateActionPerformOnRequestAccessNotificationMessage(page, "Author", catalogName, byUser);
+		Assertions.assertEquals(actualNotificationMessage,
+				"Your request for Author permission on " + catalogName + " has been approved by " + byUser + ".");
+		NotificationsUtils.closeNotificationPane(page);
+		logout(page);
+		loginAdmin(page);
 	}
 
 	@AfterEach
@@ -126,4 +177,5 @@ public class NotificationsTests extends AbstractPlaywrightTestBase {
 		}
 		logout(page);
 	}
+
 }


### PR DESCRIPTION
## Description
Implement the script for validate the notification when user make the application as discoverable and then another user sent the access request to the Admin User and Admin user accept the request 

## How to Test

1. Login the Application
2. Create the New Model 
3. Make the Model as Discoverable
4. Login as Another User
5. Sent the Request for Access the Model with Author permission 
6. Logout the another user
7. Login as Admin User
8. Navigate to the respective Model
9. Accept The Request
10. Logout as Admin User
11. Login as another User 
12. Then Verify the Notification 
 
