### PR TITLE
feat: Validated access request denied notification message

### DIFF
--- a/src/main/java/aicore/pages/notifications/NotificationsUtils.java
+++ b/src/main/java/aicore/pages/notifications/NotificationsUtils.java
@@ -8,7 +8,7 @@ public class NotificationsUtils {
 	public static final String NOTIFICATION_PANE_CLOSE_XPATH = "//h2[text()='Notifications']/parent::div/following-sibling::button[span[text()='Close']]";
 	public static final String USER_ADDED_NOTIFICATION_MESSAGE_FOR_OWNER_XPATH = "//div[@data-testid='notification-item'][.//span[normalize-space()='{accessProvided}'] and .//span[normalize-space()='{catalogName}']] //div[span[contains(text(),'has been added as')]]";
 	public static final String USER_ADDED_NOTIFICATION_MESSAGE_FOR_OTHER_OWNER_XPATH = "//div[@data-testid='notification-item'][.//span[normalize-space()='{accessProvided}'] and .//span[normalize-space()='{catalogName}'] and .//span[normalize-space()='{accessProvidedByUser}']]//div[span[contains(text(),'has been added as')]]";
-	public static final String REQUEST_ACTION_NOTIFICATION_XPATH = "//div[@data-testid='notification-item']//div[@class='text-sm'][.//span[normalize-space()='Your request for'] and .//span[normalize-space()='{accessType}'] and .//span[normalize-space()='permission on'] and .//span[normalize-space()='{catalogName}'] and .//span[normalize-space()='has been approved by'] and .//span[contains(text(),'{userName}')]]";
+	public static final String REQUEST_ACTION_NOTIFICATION_XPATH = "//div[@data-testid='notification-item']//div[@class='text-sm'][.//span[normalize-space()='Your request for'] and .//span[normalize-space()='{accessType}'] and .//span[normalize-space()='permission on'] and .//span[normalize-space()='{catalogName}'] and .//span[contains(text(),'{action}')] and .//span[contains(text(),'{userName}')]]";
 
 	public static void clickOnNotificationBellIcon(Page page) {
 		page.locator(NOTIFICATION_BELL_ICON_XPATH_).click();
@@ -47,9 +47,10 @@ public class NotificationsUtils {
 	}
 
 	public static String validateActionPerformOnRequestAccessNotificationMessage(Page page, String accessType,
-			String catalogName, String byUser) {
+			String catalogName, String action, String byUser) {
 		String actualMessage = page.locator(REQUEST_ACTION_NOTIFICATION_XPATH.replace("{accessType}", accessType)
-				.replace("{catalogName}", catalogName).replace("{userName}", byUser)).textContent().trim();
+				.replace("{catalogName}", catalogName).replace("{action}", action).replace("{userName}", byUser))
+				.textContent().trim();
 		return actualMessage;
 	}
 }

--- a/src/test/java/aicore/unit/notifications/model/NotificationsTests.java
+++ b/src/test/java/aicore/unit/notifications/model/NotificationsTests.java
@@ -123,8 +123,8 @@ public class NotificationsTests extends AbstractPlaywrightTestBase {
 	}
 
 	@Test
-	@DisplayName("Validate Notification message for Accept the request")
-	public void testAcceptRequestAndValidateMemberList(@PWPage Page page) {
+	@DisplayName("Validate notification message for request reject")
+	public void verifyAccessRequestAcceptedNotification(@PWPage Page page) {
 		AddFunctionPageUtils.clickOnAccessControl(page);
 		FunctionAccessSettingsUtils.clickOnMakeDiscoverableButton(page, "Model");
 		logout(page);
@@ -156,10 +156,56 @@ public class NotificationsTests extends AbstractPlaywrightTestBase {
 		loginEditor(page);
 		NotificationsUtils.clickOnNotificationBellIcon(page);
 		String byUser = ConfigUtils.getValue("Admin".toUpperCase() + "_USERNAME").split("@")[0];
-		String actualNotificationMessage = NotificationsUtils
-				.validateActionPerformOnRequestAccessNotificationMessage(page, "Author", catalogName, byUser);
+		String actualNotificationMessage = NotificationsUtils.validateActionPerformOnRequestAccessNotificationMessage(
+				page, "Author", catalogName, "approved", byUser);
 		Assertions.assertEquals(actualNotificationMessage,
 				"Your request for Author permission on " + catalogName + " has been approved by " + byUser + ".");
+		NotificationsUtils.closeNotificationPane(page);
+		logout(page);
+		loginAdmin(page);
+	}
+
+	@Test
+	@DisplayName("Validate notification message for request denied")
+	public void verifyAccessRequestRejectedNotification(@PWPage Page page) {
+		// Make catalog discoverable
+		AddFunctionPageUtils.clickOnAccessControl(page);
+		FunctionAccessSettingsUtils.clickOnMakeDiscoverableButton(page, "Model");
+		logout(page);
+		loginEditor(page);
+		// Request for access
+		MainMenuUtils.openMainMenu(page);
+		MainMenuUtils.clickOnOpenModel(page);
+		SettingsModelPageUtils.clickOnDiscoverableModelsButton(page);
+		EditModelPageUtils.searchModelCatalog(page, catalogName);
+		EditModelPageUtils.selectModelFromSearchOptions(page, catalogName);
+		EditModelPageUtils.clickOnRequestAccessButtonOfDiscoverableCatalog(page);
+		RequestAccessPopupUtils.selectAccessType(page, "author");
+		RequestAccessPopupUtils.enterComment(page, "Access Request");
+		RequestAccessPopupUtils.clickOnRequestButton(page);
+		logout(page);
+		loginAdmin(page);
+		// Perform action on access request
+		MainMenuUtils.openMainMenu(page);
+		MainMenuUtils.clickOnOpenModel(page);
+		EditModelPageUtils.searchModelCatalog(page, catalogName);
+		EditModelPageUtils.selectModelFromSearchOptions(page, catalogName);
+		AddFunctionPageUtils.clickOnAccessControl(page);
+		String actualCountWithText = SettingsModelPageUtils.getPendingRequestCountText(page);
+		Assertions.assertEquals("1 pending request", actualCountWithText, "Pending request text not correct");
+		SettingsModelPageUtils.clickOnPendingRequestsExpandButton(page);
+		SettingsModelPageUtils.performActionOnPendingRequest(page, "Reject");
+		String actualMessage = ModelPageUtils.modelCreationToastMessage(page, "Successfully denied user permissions");
+		Assertions.assertEquals(actualMessage, "Successfully denied user permissions", "Toast message not correct");
+		logout(page);
+		loginEditor(page);
+		// validate request denied notification message
+		NotificationsUtils.clickOnNotificationBellIcon(page);
+		String byUser = ConfigUtils.getValue("Admin".toUpperCase() + "_USERNAME").split("@")[0];
+		String actualNotificationMessage = NotificationsUtils
+				.validateActionPerformOnRequestAccessNotificationMessage(page, "Author", catalogName, "denied", byUser);
+		Assertions.assertEquals(actualNotificationMessage,
+				"Your request for Author permission on " + catalogName + " has been denied by " + byUser + ".");
 		NotificationsUtils.closeNotificationPane(page);
 		logout(page);
 		loginAdmin(page);


### PR DESCRIPTION
## Description
Implement a script to validate the access request denied notification when a user makes the application discoverable, another user submits an access request, and the admin user approves that request.

## How to Test
1. Login the Application
2. Create the New Model
3. Make the Model as Discoverable
4. Login as Another User
5. Sent the Request for Access the Model with Author permission
6. Logout the another user
7. Login as Admin User
8. Navigate to the respective Model
9. Denied the Request
10. Logout as Admin User
11. Login as another User
12. Validate the Notification message